### PR TITLE
Make sure release build artifacts get cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ rust:
 cache: cargo
 script:
 - cargo test
+- if [ "$TRAVIS_BRANCH" = "master" ]; then cargo build --release; fi
 before_deploy:
 - >
   if ! [ "$BEFORE_DEPLOY_RUN" ]; then
-    cargo build --release
     mv target/release/hangry-river-horse .
     zip -r latest.zip . -x "target/*" -x ".git/*"
     mkdir -p dpl_cd_upload


### PR DESCRIPTION
When I initially setup caching, I didn't realize that Travis only caches the artifacts created in the `script` step, so the release artifacts weren't getting cached. As a result, the change actually made `master` builds *longer*, because it added the time involved to download/setup the cache, but didn't speed up the release builds. This PR changes the release build to happen as part of the `script` step, ensuring that Travis caches all build dependencies properly.