### PR TITLE
Use a LOT of worker threads to fake concurrency

### DIFF
--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,12 +1,15 @@
 [development]
 address = "localhost"
 port = 8000
+workers = 128
 
 [staging]
 address = "0.0.0.0"
 port = 80
 log = "normal"
+workers = 128
 
 [production]
 address = "0.0.0.0"
 port = 80
+workers = 128


### PR DESCRIPTION
I'm configuring Rocket to use a whole lot of worker threads (128, to be precise) in order to work around an issue that we're seeing in production. The short description is that when there are very few worker threads (on the production instance there are only 2) the loading the host or client page can cause the entire server to lock up. You can see a discussion of there error here: https://github.com/SergioBenitez/Rocket/issues/243#issuecomment-289317578.

Using a lot of worker threads is a quick solution, but a better solution would be to setup NGINX as a reverse-proxy to handle the requests. That said, I think using a bunch of worker threads may also help with the issues we were seeing with only 2 player being able to really play at once, so I'm going to push this fix through and we can see what impact it has in production.