### PR TITLE
Adding Vendor Prefixes to disable text selection on iOS / Safari (#33)

### DIFF
--- a/www/client.css
+++ b/www/client.css
@@ -15,7 +15,13 @@ h1 {
     box-sizing: border-box;
 
     overflow: hidden;
-    user-select: none;
+
+    -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+    -khtml-user-select: none; /* Konqueror HTML */
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* Internet Explorer/Edge */
+    user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
 
     font-family: 'Baloo', cursive;
     text-align: center;


### PR DESCRIPTION
Pretty much copied over the vendor CSS from [this SO post](https://stackoverflow.com/questions/826782/how-to-disable-text-selection-highlighting-using-css/4407335#4407335).

Closes #33