### PR TITLE
Basic feeding mechanic

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,7 @@ use rocket::http::Status;
 use rocket::response::*;
 use rocket::State;
 use rocket_contrib::JSON;
-use std::sync::*;
+use std::time::*;
 
 /// The response sent back from the `/register-player` endpoint.
 #[derive(Debug, Serialize)]
@@ -13,6 +13,7 @@ pub struct RegisterPlayerResponse {
     /// The `PlayerId` that was generated for the new player.
     pub id: PlayerId,
     pub username: String,
+    pub balls: usize,
 }
 
 /// Generates a `PlayerId` for a new player.
@@ -20,39 +21,42 @@ pub struct RegisterPlayerResponse {
 #[get("/register-player")]
 pub fn register_player(
     player_id_generator: State<PlayerIdGenerator>,
-    scoreboard: State<Mutex<Scoreboard>>,
-    usernames: State<Mutex<Usernames>>,
+    players: State<PlayerMap>,
     broadcaster: State<HostBroadcaster>,
 ) -> JSON<RegisterPlayerResponse>
 {
-    let player_id = player_id_generator.next_id();
+    let id = player_id_generator.next_id();
     let username = game::generate_username();
+    let balls = 10;
 
-    // Add the username to the Usernames map
-    {
-        let mut usernames = usernames.lock().expect("Usernames mutex was poisoned");
-        let old = usernames.insert(player_id, username.clone());
-        assert_eq!(None, old, "Player ID was registered twice");
+    let player = Player {
+        id,
+        username: username.clone(),
+        score: 0,
+        balls,
+        next_eat_time: Instant::now() + Duration::from_millis(1000),
     };
 
-    // Add the player to the scoreboard.
+    // Add the player to the game state.
     {
-        let mut scoreboard = scoreboard.lock().expect("Scoreboard mutex was poisoned");
-        let old = scoreboard.insert(player_id, 0);
-        assert_eq!(None, old, "Player ID was registered twice");
+        let mut players = players.write().expect("Players map was poisoned!");
+        let old = players.insert(id, player);
+        assert!(old.is_none(), "Player ID was registered twice");
     }
 
     // Broadcast to all hosts that a new player has joined.
-    broadcaster.send(HostBroadcast::PlayerRegistered(PlayerData {
-        id: player_id,
+    broadcaster.send(HostBroadcast::PlayerRegister {
+        id,
         username: username.clone(),
         score: 0,
-    }));
+        balls,
+    });
 
     // Respond to the client.
     JSON(RegisterPlayerResponse {
-        id: player_id,
-        username: username,
+        id,
+        username,
+        balls,
     })
 }
 
@@ -66,7 +70,7 @@ pub struct FeedPlayerRequest {
 /// The response sent back from the `/feed-me` endpoint.
 #[derive(Debug, Serialize)]
 pub struct FeedPlayerResponse {
-    score: usize,
+    balls: usize,
 }
 
 /// Feeds a player's hippo, increasing the player's score.
@@ -78,36 +82,29 @@ pub struct FeedPlayerResponse {
 #[post("/feed-me", format = "application/json", data = "<payload>")]
 pub fn feed_player(
     payload: JSON<FeedPlayerRequest>,
-    scoreboard: State<Mutex<Scoreboard>>,
+    players: State<PlayerMap>,
     broadcaster: State<HostBroadcaster>,
 ) -> Result<JSON<FeedPlayerResponse>>
 {
     let payload = payload.into_inner();
-    let player_id = payload.player;
+    let id = payload.player;
 
     // Add 1 to the player's score, returning the new score.
-    let score = {
-        let mut scoreboard = scoreboard.lock().expect("Scoreboard mutex was poisoned");
+    let balls = {
+        let mut players = players.write().expect("Players were poisoned");
 
         // Get the player's current score, or return an `InvalidPlayer` error if it's not in
         // the scoreboard.
-        let score = scoreboard
-            .get_mut(&player_id)
-            .ok_or(Error::InvalidPlayer(player_id))?;
-        *score += 1;
-        *score
+        let player = players
+            .get_mut(&id)
+            .ok_or(Error::InvalidPlayer(id))?;
+        player.balls += 1;
+        player.balls
     };
 
-    // Broadcast the new score to all hosts.
-    broadcaster.send(HostBroadcast::PlayerScore {
-        id: player_id,
-        score: score,
-    });
-
-    // Respond to the client.
-    Ok(JSON(FeedPlayerResponse {
-        score: score,
-    }))
+    // Update the host displays and respond to the player.
+    broadcaster.send(HostBroadcast::AddBall { id, balls });
+    Ok(JSON(FeedPlayerResponse { balls }))
 }
 
 /// The response sent back from the `/scoreboard` endpoint.
@@ -119,24 +116,29 @@ pub struct PlayersResponse {
     pub players: Vec<PlayerData>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct PlayerData {
+    id: PlayerId,
+    username: String,
+    score: usize,
+    balls: usize,
+}
+
 /// Returns a list of players and their scores.
 ///
 /// This is used by new host connections to update thier display to match the current state of the
 /// game.
 #[get("/players")]
-pub fn get_players(
-    scoreboard: State<Mutex<Scoreboard>>,
-    usernames: State<Mutex<Usernames>>,
-) -> JSON<PlayersResponse> {
-    // Clone the scoreboard and usernames table so we can work on their data without holding the
-    // mutex for too long.
-    let scoreboard = scoreboard.lock().expect("Scoreboard mutex was poisoned").clone();
-    let mut usernames = usernames.lock().expect("Usernames mutex was poisoned").clone();
-
-    let players = usernames.drain()
-        .map(|(id, username)| {
-            let score = *scoreboard.get(&id).expect("Score for player was not in scoreboard");
-            PlayerData { id, username, score }
+pub fn get_players(players: State<PlayerMap>) -> JSON<PlayersResponse> {
+    let players = players.read().expect("Player map was poisoned!");
+    let players = players.values()
+        .map(|player| {
+            PlayerData {
+                id: player.id,
+                username: player.username.clone(),
+                score: player.score,
+                balls: player.balls,
+            }
         })
         .collect();
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -116,11 +116,22 @@ pub struct PlayersResponse {
     pub players: Vec<PlayerData>,
 }
 
+/// The current state for a player that is needed by the host site.
+///
+/// This doesn't include all of the player's internal state data, only the information needed
+/// by the display site.
 #[derive(Debug, Serialize)]
 pub struct PlayerData {
+    /// The player's ID.
     id: PlayerId,
+
+    /// The player's display name.
     username: String,
+
+    /// The player's current score.
     score: usize,
+
+    /// The total number of balls in the players food pile.
     balls: usize,
 }
 

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -31,6 +31,10 @@ pub enum HostBroadcast {
         score: usize,
         balls: usize,
     },
+
+    PlayerLose {
+        id: PlayerId,
+    }
 }
 
 /// A message to be broadcast to connected player clients.

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -119,7 +119,6 @@ where
         // websockets connected to the server.
         for broadcast in broadcast_receiver {
             let payload = ::serde_json::to_string(&broadcast).expect("Failed to serialize payload");
-            println!("About to broadcast payload: {:?}", payload);
             socket.broadcast(payload.clone()).unwrap();
         }
     });

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -14,24 +14,43 @@ pub type PlayerBroadcaster = Arc<Broadcaster<PlayerBroadcast>>;
 /// A message to be broadcast to connected host clients.
 #[derive(Debug, Serialize)]
 pub enum HostBroadcast {
+    /// A new player has joined the game and should be added to the display.
     PlayerRegister {
+        // The ID of the new player.
         id: PlayerId,
+
+        // The player's display name.
         username: String,
+
+        /// The starting score for the player.
         score: usize,
+
+        /// The starting number of balls in the player's food pile.
         balls: usize,
     },
 
+    /// A player has added a ball to their food pile.
     AddBall {
+        /// The ID of the player who got the ball.
         id: PlayerId,
+
+        /// The total number of balls in the player's food pile.
         balls: usize,
     },
 
+    /// A hippo has eaten a ball from their food pile.
     HippoEat {
+        /// The ID for the player whose hippo ate the ball.
         id: PlayerId,
+
+        /// The player's total score.
         score: usize,
+
+        /// The total number of balls in the player's food pile.
         balls: usize,
     },
 
+    /// A player has lost the game and should be removed from the display.
     PlayerLose {
         id: PlayerId,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,9 @@ fn main() {
     let client_broadcaster = broadcast::start_server::<PlayerBroadcast>("0.0.0.0:6768");
     let host_broadcaster = broadcast::start_server::<HostBroadcast>("0.0.0.0:6769");
 
+    let hippos = HippoMap::default();
+    game::start_game_loop(hippos.clone());
+
     // Start the main Rocket application.
     rocket::ignite()
         .mount("/", routes![
@@ -69,5 +72,6 @@ fn main() {
         .manage(host_broadcaster)
         .manage(client_broadcaster)
         .manage(Mutex::new(Scoreboard::new()))
+        .manage(hippos)
         .launch();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@ use game::*;
 use rocket::response::*;
 use std::io;
 use std::path::*;
-use std::sync::*;
 
 mod api;
 mod broadcast;
@@ -54,8 +53,8 @@ fn main() {
     let client_broadcaster = broadcast::start_server::<PlayerBroadcast>("0.0.0.0:6768");
     let host_broadcaster = broadcast::start_server::<HostBroadcast>("0.0.0.0:6769");
 
-    let hippos = HippoMap::default();
-    game::start_game_loop(hippos.clone());
+    let players = PlayerMap::default();
+    game::start_game_loop(players.clone(), host_broadcaster.clone());
 
     // Start the main Rocket application.
     rocket::ignite()
@@ -70,10 +69,8 @@ fn main() {
             api::get_players,
         ])
         .manage(PlayerIdGenerator::new())
+        .manage(players)
         .manage(host_broadcaster)
         .manage(client_broadcaster)
-        .manage(Mutex::new(Scoreboard::new()))
-        .manage(Mutex::new(Usernames::new()))
-        .manage(hippos)
         .launch();
 }

--- a/www/host.css
+++ b/www/host.css
@@ -104,11 +104,11 @@ body {
 }
 
 #top-side .hippo-text {
-    top: 100px;
+    top: 200px;
 }
 
 #right-side .hippo-text {
-    right: 100px;
+    right: 200px;
 }
 
 #right-side .hippo-head-image {
@@ -116,7 +116,7 @@ body {
 }
 
 #bottom-side .hippo-text {
-    bottom: 100px;
+    bottom: 200px;
 }
 
 #bottom-side .hippo-head-image {
@@ -124,7 +124,7 @@ body {
 }
 
 #left-side .hippo-text {
-    left: 100px;
+    left: 200px;
 }
 
 #left-side .hippo-head-image {

--- a/www/host.html
+++ b/www/host.html
@@ -46,6 +46,7 @@
                     v-bind:name="hippo.player.username"
                     v-bind:score="hippo.player.score"
                     v-bind:id="hippo.player.id"
+                    v-bind:balls="hippo.player.balls"
                 ></hippo-head>
             </div>
 
@@ -56,6 +57,7 @@
                     v-bind:name="hippo.player.username"
                     v-bind:score="hippo.player.score"
                     v-bind:id="hippo.player.id"
+                    v-bind:balls="hippo.player.balls"
                 >
                 </hippo-head>
             </div>
@@ -67,6 +69,7 @@
                     v-bind:name="hippo.player.username"
                     v-bind:score="hippo.player.score"
                     v-bind:id="hippo.player.id"
+                    v-bind:balls="hippo.player.balls"
                 >
                 </hippo-head>
             </div>
@@ -78,6 +81,7 @@
                     v-bind:name="hippo.player.username"
                     v-bind:score="hippo.player.score"
                     v-bind:id="hippo.player.id"
+                    v-bind:balls="hippo.player.balls"
                 >
                 </hippo-head>
             </div>

--- a/www/host.js
+++ b/www/host.js
@@ -22,12 +22,13 @@ let app = new Vue({
 });
 
 Vue.component('hippo-head', {
-    props: ['name', 'score', 'id'],
+    props: ['name', 'score', 'id', 'balls'],
     template: `
     <div class="hippo-head">
         <div class="hippo-text">
             <div class="hippo-name">{{ name }}</div>
             <div class="hippo-score">Score: {{ score }}</div>
+            <div class="hippo=balls">Balls: {{ balls }}</div>
         </div>
         <img src="assets/hippo.jpg" class="hippo-head-image" :id="id">
     </div>
@@ -56,10 +57,18 @@ socket.onmessage = (event) => {
     // TODO: Do some validation on the payload data I guess.
     let payload = JSON.parse(event.data);
 
-    if (payload['PlayerRegistered']) {
-        registerPlayer(payload['PlayerRegistered']);
-    } else if (payload['PlayerScore']) {
-        let info = payload['PlayerScore'];
+    if (payload['PlayerRegister']) {
+        registerPlayer(payload['PlayerRegister']);
+    } else if (payload['AddBall']) {
+        let info = payload['AddBall'];
+
+        // Find the hippo/player for the player that scored.
+        let hippo = app.hippoMap[info.id];
+        assert(hippo != null, 'Unable to find hippo for ID: ' + info.id);
+
+        hippo.player.balls = info.balls;
+    } else if (payload['HippoEat']) {
+        let info = payload['HippoEat'];
 
         // Find the hippo/player for the player that scored.
         let hippo = app.hippoMap[info.id];
@@ -67,6 +76,7 @@ socket.onmessage = (event) => {
 
         // Updated the local score for the player.
         hippo.player.score = info.score;
+        hippo.player.balls = info.balls;
 
         // Animate the hippo head to match the score increase. The direction of the chomp animation
         // depends on the side of the screen that the hippo is on.

--- a/www/host.js
+++ b/www/host.js
@@ -81,7 +81,7 @@ socket.onmessage = (event) => {
         // Animate the hippo head to match the score increase. The direction of the chomp animation
         // depends on the side of the screen that the hippo is on.
         let element = document.getElementById(hippo.player.id);
-        switch (hippo.side) {
+        switch (hippo.side.side) {
             case TOP_SIDE: {
                 TweenMax.fromTo(
                     element,
@@ -118,9 +118,24 @@ socket.onmessage = (event) => {
                 );
             } break;
 
-            default: throw new Error('Unrecognized hippo side: ' + hippo.side);
+            default: throw new Error('Unrecognized hippo side: ' + hippo.side.side);
         }
+    } else if (payload['PlayerLose']) {
+        let info = payload['PlayerLose'];
+
+        // Retreive the hippo and remove it from the hippo map.
+        let hippo = app.hippoMap[info.id];
+        assert(delete app.hippoMap[info.id], 'Unable to remove player for id ' + info.id);
+
+        // Remove the hippo from its side of the screen.
+        let index = hippo.side.array.indexOf(hippo);
+        hippo.side.array.splice(index, 1);
+    } else {
+        console.error('Unrecognized host event:', payload);
     }
+};
+socket.onclose = (event) => {
+    console.error('Socket closed:', event);
 };
 
 // When we first boot up we need to get the current list of players.
@@ -145,7 +160,7 @@ function registerPlayer(player) {
     // Create a hippo object for the player.
     let hippo = {
         player: player,
-        side: side.side,
+        side: side,
     };
 
     // Add the hippo to the hippo map and its side of the screen.


### PR DESCRIPTION
I've added the basic feeding mechanic described in #35:

- Players start with 10 balls in their food pile.
- A player's hippo eats a ball from their food pile every 0.75 seconds.
- Each ball their hippo eats gives the player 1 point.
- If the hippo tries to eat and there are no balls, the player loses and is removed from the game and the host screen.

This provides a baseline auto-removal mechanism to the game, which should fix our issues with overcrowded screens. More work needs to be done for #35, but this is working well enough to deploy it while we add more functionality.