### PR TITLE
Add nose-goes feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,9 @@ name = "hangry-river-horse"
 version = "0.4.0"
 dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_contrib 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -13,21 +13,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "base64"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -35,13 +30,13 @@ name = "bytes"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -49,8 +44,8 @@ name = "cookie"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -73,12 +68,12 @@ dependencies = [
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -86,9 +81,9 @@ name = "idna"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -96,7 +91,7 @@ name = "iovec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -126,7 +121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.23"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -136,7 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "matches"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -144,7 +139,7 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -163,7 +158,7 @@ dependencies = [
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -187,25 +182,30 @@ name = "net2"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.37"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.5.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -217,51 +217,51 @@ name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.18"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rocket"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "state 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "term-painter 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_contrib"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -296,7 +296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "term"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -347,17 +347,17 @@ name = "term-painter"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -386,15 +386,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -404,11 +404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "url"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -431,7 +432,7 @@ name = "ws"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -439,7 +440,7 @@ dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -451,12 +452,16 @@ dependencies = [
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "yansi"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
-"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30e93c03064e7590d0466209155251b90c22e37fab1daf2771582598b5827557"
-"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b24f16593f445422331a5eed46b72f7f171f910fead4f2ea8f17e727e9c5c14"
-"checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cookie 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30b3493e12a550c2f96be785088d1da8d93189e7237c8a8d0d871bc9070334c3"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
@@ -467,22 +472,23 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
-"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+"checksum libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "30885bcb161cf67054244d10d4a7f4835ffd58773bc72e07d35fecf472295503"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
-"checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
+"checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "bc01404e7568680f1259aa5729539f221cb1e6d047a0d9053cab4be8a73b5d67"
-"checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
-"checksum num_cpus 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e416ba127a4bb3ff398cb19546a8d0414f73352efe2857f4060d36f5fe5983a"
+"checksum num-traits 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "1708c0628602a98b52fad936cf3edb9a107af06e52e49fdf0707e884456a6af6"
+"checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
+"checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
-"checksum redox_syscall 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "3041aeb6000db123d2c9c751433f526e1f404b23213bd733167ab770c3989b4d"
-"checksum rocket 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "371b8fbbe588a08fbc858553153c1a4b6c864848260b8105ae81ef93470e09ad"
-"checksum rocket_codegen 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "62813eaa298ffa6b2dd0de4318670985b900bec6c4dd9a249450ea5d98e67f2b"
-"checksum rocket_contrib 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "49173eb7adb6cd93a10ef8e904c54b3c49ec7caef0f1caf14bce6b0ae57d7686"
+"checksum redox_syscall 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "9aa093607d28cfd65f317edeeefb6749be428eacc8decd1c5f8c0fbcc327aff5"
+"checksum rocket 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3817ed527a346be15d3c4f97e791c7534ae9ddbe516b464644fd36bc9bd0bd47"
+"checksum rocket_codegen 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ea317297ec507c56a95c9fe2a521f935216068495979816e9345d8e78e6be685"
+"checksum rocket_contrib 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7acc89f77714753d197f818bf27e1f4168d11acd2459e6c7649961f3de55284a"
 "checksum serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 "checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
 "checksum serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "978fd866f4d4872084a81ccc35e275158351d3b9fe620074e7d7504b816b74ba"
@@ -492,19 +498,20 @@ dependencies = [
 "checksum state 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "99a7a6587fa4df1d26b6e32d2c5ba99583f2c818ac741b54b8a87548c349fa0d"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
+"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term-painter 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ab900bf2f05175932b13d4fc12f8ff09ef777715b04998791ab2c930841e496b"
-"checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
+"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-"checksum unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a6a2c4e3710edd365cd7e78383153ed739fa31af19f9172f72d3575060f5a43a"
-"checksum unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e28fa37426fceeb5cf8f41ee273faa7c82c47dc8fba5853402841e665fcd86ff"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-"checksum url 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2ba3456fbe5c0098cb877cf08b92b76c3e18e0be9e47c35b487220d377d24e"
+"checksum url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb819346883532a271eb626deb43c4a1bb4c4dd47c519bd78137c3e72a4fe27"
 "checksum version_check 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2bb3950bf29e36796dea723df1747619dd331881aefef75b7cf1c58fdd738afe"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89c48c53bf9dee34411a08993c10b879c36e105d609b46e25673befe3a5c1320"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum yansi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b731f15b7c13b4988f2836d88ce92b699c72dbc0178cf9d7c3ecad0d8fd1c902"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "hangry-river-horse"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 name = "hangry-river-horse"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 rand = "0.3.15"

--- a/src/api.rs
+++ b/src/api.rs
@@ -117,8 +117,6 @@ pub enum NoseGoesResponse {
 pub fn nose_goes(
     id: PlayerId,
     nose_goes: State<NoseGoesState>,
-    player_broadcaster: State<PlayerBroadcaster>,
-    host_broadcaster: State<HostBroadcaster>,
 ) -> Result<JSON<NoseGoesResponse>> {
     let mut nose_goes = nose_goes.lock().expect("Nose-goes state was poisoned!");
     match *nose_goes {
@@ -126,7 +124,7 @@ pub fn nose_goes(
             Err(Error::InvalidNoesGoes)
         }
 
-        NoseGoes::InProgress { remaining_players, .. } => {
+        NoseGoes::InProgress { ref mut remaining_players, .. } => {
             // It's an error for the player to not be part of the nose-goes event.
             if !remaining_players.contains(&id) {
                 return Err(Error::InvalidNoesGoes);

--- a/src/api.rs
+++ b/src/api.rs
@@ -83,8 +83,7 @@ pub fn feed_player(
     payload: JSON<FeedMeRequest>,
     players: State<PlayerMap>,
     broadcaster: State<HostBroadcaster>,
-) -> Result<JSON<FeedMeResponse>>
-{
+) -> Result<JSON<FeedMeResponse>> {
     let payload = payload.into_inner();
     let id = payload.id;
 
@@ -106,6 +105,43 @@ pub fn feed_player(
     // Update the host displays and respond to the player.
     broadcaster.send(HostBroadcast::HippoEat { id, score });
     Ok(JSON(FeedMeResponse { score }))
+}
+
+#[derive(Debug, Serialize)]
+pub enum NoseGoesResponse {
+    Survived,
+    Died,
+}
+
+#[post("/nose-goes/<id>")]
+pub fn nose_goes(
+    id: PlayerId,
+    nose_goes: State<NoseGoesState>,
+    player_broadcaster: State<PlayerBroadcaster>,
+    host_broadcaster: State<HostBroadcaster>,
+) -> Result<JSON<NoseGoesResponse>> {
+    let mut nose_goes = nose_goes.lock().expect("Nose-goes state was poisoned!");
+    match *nose_goes {
+        NoseGoes::Inactive { .. } => {
+            Err(Error::InvalidNoesGoes)
+        }
+
+        NoseGoes::InProgress { remaining_players, .. } => {
+            // It's an error for the player to not be part of the nose-goes event.
+            if !remaining_players.contains(&id) {
+                return Err(Error::InvalidNoesGoes);
+            }
+
+            // If there are multiple players still in the event, remove the player. If the player
+            // is the last one left, they die.
+            if remaining_players.len() > 1 {
+                remaining_players.remove(&id);
+                Ok(JSON(NoseGoesResponse::Survived))
+            } else {
+                Ok(JSON(NoseGoesResponse::Died))
+            }
+        }
+    }
 }
 
 /// The response sent back from the `/scoreboard` endpoint.
@@ -162,6 +198,14 @@ pub enum Error {
     /// now trying to use the ID in a session where it is no longer valid. Re-registering the
     /// player to generate a new ID should fix the issue.
     InvalidPlayer(PlayerId),
+
+    /// Indicates that a noes-goes request was not valid.
+    ///
+    /// This can occur for two reasons:
+    ///
+    /// - The request arrived when no noes-goes event was active.
+    /// - The player was not a part of the active noes-goes event.
+    InvalidNoesGoes,
 }
 
 impl<'r> Responder<'r> for Error {

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -6,6 +6,7 @@
 use game::*;
 use std::sync::*;
 use std::thread;
+use std::time::*;
 use ws;
 
 pub type HostBroadcaster = Arc<Broadcaster<HostBroadcast>>;
@@ -35,15 +36,33 @@ pub enum HostBroadcast {
         score: usize,
     },
 
-    /// A player has lost the game and should be removed from the display.
-    PlayerLose {
-        id: PlayerId,
-    }
+    /// A nose-goes event has begun, and the host should display the event.
+    BeginNoseGoes {
+        /// The duration that the nose-goes event will last.
+        duration: Duration,
+
+        /// The players that are participating in the event.
+        players: Vec<PlayerId>,
+    },
+
+    /// A nose-goes event has ended, and a player has been knocked out.
+    EndNoseGoes {
+        /// The player that got knocked out at the end of the event.
+        loser: PlayerId,
+    },
 }
 
 /// A message to be broadcast to connected player clients.
 #[derive(Debug, Serialize)]
 pub enum PlayerBroadcast {
+    /// A nose-goes event has begun, and the player should be prompted to participate.
+    BeginNoseGoes,
+
+    /// A nose-goes event has finished, and a player has been knocked out.
+    EndNoseGoes {
+        loser: PlayerId,
+    },
+
     /// A player has lost the game and has been removed.
     PlayerLose {
         /// The ID for the player that thi event applies to.

--- a/src/game.rs
+++ b/src/game.rs
@@ -242,7 +242,7 @@ pub fn start_game_loop(
     thread::spawn(move || {
         // NOTE: These should be `const`, but you can't make a const `Duration`.
         let nose_goes_duration = Duration::from_millis(10_000);
-        let nose_goes_interval = Duration::from_millis(10_000);
+        let nose_goes_interval = Duration::from_millis(30_000);
 
         loop {
             let now = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ fn main() {
             api::register_player,
             api::feed_player,
             api::get_players,
+            api::nose_goes,
         ])
         .manage(PlayerIdGenerator::default())
         .manage(players)

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,10 @@ fn main() {
     let host_broadcaster = broadcast::start_server::<HostBroadcast>("0.0.0.0:6769");
 
     let players = PlayerMap::default();
+    let nose_goes = NoseGoesState::default();
     game::start_game_loop(
         players.clone(),
+        nose_goes.clone(),
         host_broadcaster.clone(),
         player_broadcaster.clone(),
     );
@@ -74,6 +76,7 @@ fn main() {
         ])
         .manage(PlayerIdGenerator::default())
         .manage(players)
+        .manage(nose_goes)
         .manage(host_broadcaster)
         .manage(player_broadcaster)
         .launch();

--- a/www/client.css
+++ b/www/client.css
@@ -82,3 +82,25 @@ button {
 .hippo-name {
     color: #bc00a6;
 }
+
+#nose-goes-overlay {
+    width: 100vw;
+    height: 100vh;
+    z-index: 1;
+
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    background-color: rgba(0, 0, 0, 0.3);
+}
+
+#poison-marble {
+    width: 100px;
+    height: 100px;
+    border-radius: 50px;
+
+    position: absolute;
+
+    background-color: red;
+}

--- a/www/client.html
+++ b/www/client.html
@@ -58,7 +58,11 @@
             </div>
 
             <div id="nose-goes-overlay" v-if="noseGoes.isActive">
-                <div id="poison-marble" v-bind:style="{ top: (noseGoes.marbleY * 100) + '%', left: (noseGoes.marbleX * 100) + '%' }"></div>
+                <div
+                    id="poison-marble"
+                    v-bind:style="{ top: (noseGoes.marbleY * 100) + '%', left: (noseGoes.marbleX * 100) + '%' }"
+                    v-on:click="poisonMarble"
+                ></div>
             </div>
         </div>
 

--- a/www/client.html
+++ b/www/client.html
@@ -56,6 +56,10 @@
                 <div id="final-score-text">Your final score is {{ score }}.</div>
                 <button v-on:click.stop="reload">Play Again</button>
             </div>
+
+            <div id="nose-goes-overlay" v-if="noseGoes.isActive">
+                <div id="poison-marble" v-bind:style="{ top: (noseGoes.marbleY * 100) + '%', left: (noseGoes.marbleX * 100) + '%' }"></div>
+            </div>
         </div>
 
         <!-- Load script for the client. -->

--- a/www/client.html
+++ b/www/client.html
@@ -52,7 +52,7 @@
 
             <div id="lose-screen" class="screen" v-if="!isPlaying">
                 <h2 id="game-over-text">Game Over</h2>
-                <div id="game-over-message">Your hippo <span class="hippo-name">{{ username }}</span> ran out of colorful marbles to eat.</div>
+                <div id="game-over-message">Your hippo <span class="hippo-name">{{ hippoName }}</span> ate a poison marble and died.</div>
                 <div id="final-score-text">Your final score is {{ score }}.</div>
                 <button v-on:click.stop="reload">Play Again</button>
             </div>

--- a/www/client.js
+++ b/www/client.js
@@ -9,6 +9,11 @@ let app = new Vue({
         hippoName: null,
         score: null,
         isPlaying: true,
+        noseGoes: {
+            isActive: false,
+            marbleX: 0,
+            marbleY: 0,
+        },
     },
 
     methods: {
@@ -49,10 +54,23 @@ let app = new Vue({
 // actually a good idea, but whatevs.
 let socket = new WebSocket('ws://' + window.location.hostname + ':6768');
 socket.onmessage = function(event) {
+    // Ignore websocket events if the game is over.
+    if (!app.isPlaying) {
+        return;
+    }
+
     // TODO: Do some kind of validation.
     let payload = JSON.parse(event.data);
+    console.log(payload);
 
-    if (payload['HippoEat']) {
+    if (payload === 'BeginNoseGoes') {
+        app.noseGoes.isActive = true;
+        app.noseGoes.marbleX = Math.random();
+        app.noseGoes.marbleY = Math.random();
+    } else if (payload['EndNoseGoes']) {
+        // TODO: Do some kind of animation when the player is the one who lost?
+        app.noseGoes.isActive = false;
+    } else if (payload['HippoEat']) {
         let event = payload['HippoEat'];
         if (event.id === app.id) {
             app.score = event.score;

--- a/www/client.js
+++ b/www/client.js
@@ -54,6 +54,7 @@ let app = new Vue({
                     // TODO: What do we do if the player survived?
                 } else if (response === 'Died') {
                     // TODO: Do we handle the player's death now or what?
+                    app.isPlaying = false;
                 } else {
                     console.error('Unrecognized nose-goes result:', response);
                 }
@@ -75,7 +76,6 @@ socket.onmessage = function(event) {
 
     // TODO: Do some kind of validation.
     let payload = JSON.parse(event.data);
-    console.log(payload);
 
     if (payload === 'BeginNoseGoes') {
         app.noseGoes.isActive = true;

--- a/www/client.js
+++ b/www/client.js
@@ -20,7 +20,7 @@ let app = new Vue({
         feedMe: function () {
             // If the user taps after they've lost, don't do anything.
             // TODO: Can we have Vue remove the binding when `isPlaying` is false?
-            if (!this.isPlaying) {
+            if (!this.isPlaying || this.noseGoes.isActive) {
                 return;
             }
 
@@ -46,6 +46,20 @@ let app = new Vue({
 
         reload: function () {
             window.location.reload(false);
+        },
+
+        poisonMarble: function () {
+            post(`/api/nose-goes/${this.id}`, {}, response => {
+                if (response.result === 'Survived') {
+                    // TODO: What do we do if the player survived?
+                } else if (response.result === 'Died') {
+                    // TODO: Do we handle the player's death now or what?
+                } else {
+                    console.error('Unrecognized nose-goes result:', response.result);
+                }
+            });
+
+            this.noseGoes.isActive = false;
         }
     },
 });
@@ -54,8 +68,8 @@ let app = new Vue({
 // actually a good idea, but whatevs.
 let socket = new WebSocket('ws://' + window.location.hostname + ':6768');
 socket.onmessage = function(event) {
-    // Ignore websocket events if the game is over.
-    if (!app.isPlaying) {
+    // Ignore websocket events if the game is over or there's a nose-goes event.
+    if (!app.isPlaying && !app.noseGoes.isActive) {
         return;
     }
 

--- a/www/client.js
+++ b/www/client.js
@@ -50,12 +50,12 @@ let app = new Vue({
 
         poisonMarble: function () {
             post(`/api/nose-goes/${this.id}`, {}, response => {
-                if (response.result === 'Survived') {
+                if (response === 'Survived') {
                     // TODO: What do we do if the player survived?
-                } else if (response.result === 'Died') {
+                } else if (response === 'Died') {
                     // TODO: Do we handle the player's death now or what?
                 } else {
-                    console.error('Unrecognized nose-goes result:', response.result);
+                    console.error('Unrecognized nose-goes result:', response);
                 }
             });
 

--- a/www/host.css
+++ b/www/host.css
@@ -171,3 +171,14 @@ body {
     font-size: 130%;
     color: #bc00a6;
 }
+
+#nose-goes {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    white-space: nowrap;
+
+    font-size: 300%;
+    color: red;
+}

--- a/www/host.html
+++ b/www/host.html
@@ -70,10 +70,14 @@
                     v-bind:hippo="hippo"
                 ></hippo-head>
             </div>
-        </div>
 
-        <div id="attract-message">
-            Go to <span id="site-address">http://hungryhipp.us/</span> to play!
+            <div id="attract-message" v-show="!noseGoes.isActive">
+                Go to <span id="site-address">http://hungryhipp.us/</span> to play!
+            </div>
+
+            <div id="nose-goes" v-show="noseGoes.isActive">
+                Look at your phone!
+            </div>
         </div>
 
         <!-- Load script for the host. -->


### PR DESCRIPTION
This is a first-pass at a nose-goes mechanic. Every 30 seconds or so a nose-goes event kicks off. All active players are added to the pool of players involved in the event. When the event starts, the host display replaces the attract message with a message saying "Look at your phone!". The player's display dims and a red poison pill appears on their screen. The players must each tap the poison pill on their screen to get rid of it. The last player to have not tapped their pill is knocked out of the game. The event is also limited to 10 seconds, if more than one player is left after that time then one will be picked at random as the loser.

There are few improvements left to be made in the future changes:

* We need more clear messaging as to what the player is doing during the nose-goes event.
* It would be better if the player could swipe the poison pill away instead of tapping it.
* The nose-goes event should end as soon as all-but-one of the players has tapped their poison pill. Currently it will always last the full 10 seconds.

NOTE: I've also updated the version of Rocket we're using. There was a breaking change in some of the unstable internals on a recent nightly, so we need to update Rocket to get travis builds working again.