### PR TITLE
Fix deadlock issue with nose-goes

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -247,69 +247,71 @@ pub fn start_game_loop(
         loop {
             let now = Instant::now();
 
-            let mut nose_goes = nose_goes.lock().expect("Nose-goes state was poisoned!");
+            {
+                let mut nose_goes = nose_goes.lock().expect("Nose-goes state was poisoned!");
 
-            // Match the current nose-goes state, and return the new state.
-            //
-            // NOTE: We use `mem::replace` to move the current state out of the `Mutex`, so that we
-            // can safely destructure and mutate it.
-            *nose_goes = match mem::replace(&mut *nose_goes, NoseGoes::default()) {
-                NoseGoes::Inactive { next_start_time } => {
-                    let players = players.read().expect("Player map was poisoned!");
-                    if now > next_start_time {
-                        if players.len() > 1 {
-                            // Add all players to the nose-goes event.
-                            let remaining_players: HashSet<PlayerId> = players.keys().cloned().collect();
+                // Match the current nose-goes state, and return the new state.
+                //
+                // NOTE: We use `mem::replace` to move the current state out of the `Mutex`, so that we
+                // can safely destructure and mutate it.
+                *nose_goes = match mem::replace(&mut *nose_goes, NoseGoes::default()) {
+                    NoseGoes::Inactive { next_start_time } => {
+                        let players = players.read().expect("Player map was poisoned!");
+                        if now > next_start_time {
+                            if players.len() > 1 {
+                                // Add all players to the nose-goes event.
+                                let remaining_players: HashSet<PlayerId> = players.keys().cloned().collect();
 
-                            host_broadcaster.send(HostBroadcast::BeginNoseGoes {
-                                duration: nose_goes_duration,
-                                players: remaining_players.iter().cloned().collect(),
-                            });
-                            player_broadcaster.send(PlayerBroadcast::BeginNoseGoes);
+                                host_broadcaster.send(HostBroadcast::BeginNoseGoes {
+                                    duration: nose_goes_duration,
+                                    players: remaining_players.iter().cloned().collect(),
+                                });
+                                player_broadcaster.send(PlayerBroadcast::BeginNoseGoes);
 
-                            NoseGoes::InProgress {
-                                start_time: next_start_time,
-                                end_time: next_start_time + nose_goes_duration,
-                                remaining_players,
+                                NoseGoes::InProgress {
+                                    start_time: next_start_time,
+                                    end_time: next_start_time + nose_goes_duration,
+                                    remaining_players,
+                                }
+                            } else {
+                                // There aren't enough players to run the nose-goes event. Delay until
+                                // later.
+                                let next_start_time = next_start_time + nose_goes_interval;
+                                NoseGoes::Inactive { next_start_time }
                             }
                         } else {
-                            // There aren't enough players to run the nose-goes event. Delay until
-                            // later.
-                            let next_start_time = next_start_time + nose_goes_interval;
                             NoseGoes::Inactive { next_start_time }
                         }
-                    } else {
-                        NoseGoes::Inactive { next_start_time }
                     }
-                }
 
-                NoseGoes::InProgress { start_time, end_time, remaining_players } => {
-                    if now > end_time {
-                        // Pick a random player to be the loser.
-                        let loser = remaining_players
+                    NoseGoes::InProgress { start_time, end_time, remaining_players } => {
+                        if now > end_time {
+                            // Pick a random player to be the loser.
+                            let loser = remaining_players
                             .iter()
                             .nth(thread_rng().gen_range(0, remaining_players.len()))
                             .cloned()
                             .unwrap();
 
-                        // Remove the player from the player map.
-                        let mut players = players.write().expect("Player map was poisoned");
-                        let loser_info = players.remove(&loser).expect("Loser wasn't in player map");
+                            // Remove the player from the player map.
+                            let mut players = players.write().expect("Player map was poisoned");
+                            let loser_info = players.remove(&loser).expect("Loser wasn't in player map");
 
-                        // Broadcast player loss to players and hosts.
-                        host_broadcaster.send(HostBroadcast::EndNoseGoes { loser });
-                        player_broadcaster.send(PlayerBroadcast::EndNoseGoes { loser });
-                        player_broadcaster.send(PlayerBroadcast::PlayerLose {
-                            id: loser,
-                            score: loser_info.score,
-                        });
+                            // Broadcast player loss to players and hosts.
+                            host_broadcaster.send(HostBroadcast::EndNoseGoes { loser });
+                            player_broadcaster.send(PlayerBroadcast::EndNoseGoes { loser });
+                            player_broadcaster.send(PlayerBroadcast::PlayerLose {
+                                id: loser,
+                                score: loser_info.score,
+                            });
 
-                        NoseGoes::Inactive { next_start_time: end_time + nose_goes_interval }
-                    } else {
-                        NoseGoes::InProgress { start_time, end_time, remaining_players }
+                            NoseGoes::Inactive { next_start_time: end_time + nose_goes_interval }
+                        } else {
+                            NoseGoes::InProgress { start_time, end_time, remaining_players }
+                        }
                     }
-                }
-            };
+                };
+            }
 
             thread::sleep(Duration::from_millis(100));
         }

--- a/src/game.rs
+++ b/src/game.rs
@@ -245,9 +245,10 @@ pub fn start_game_loop(
         let nose_goes_interval = Duration::from_millis(30_000);
 
         loop {
-            let now = Instant::now();
-
+            // NOTE: Perform all logic for the loop body in this inner block. Doing so will ensure
+            // that any acquired locks will be released before the thread sleeps.
             {
+                let now = Instant::now();
                 let mut nose_goes = nose_goes.lock().expect("Nose-goes state was poisoned!");
 
                 // Match the current nose-goes state, and return the new state.


### PR DESCRIPTION
So you know how Rust is all good and stuff? Well it doesn't fix all bugs. In this case, it's still possible to deadlock if a thread grabs a mutex's lock and never lets go. In this case, the game thread was meant to release the lock on the nose-goes mutex before sleeping, but it never did. The thread held the mutex lock during its entire sleep, and would only release it briefly before returning to the top of the loop, where it would almost immediately re-acquire the lock. As a result, the thread handling the nose-goes request would never be able to acquire the lock, and would never manage to remove the player from the nose-goes event. This would result in players who successfully tapped the poison pill to still be killed in a nose-goes event.

I've fixed this by adding an explicit scope to the game loop to ensure the mutex guard for the nose-goes state is dropped at the right time. I've also added a note to remind others to be wary of the same issue in the future. If we keep running into this issue, we can further abstract the game loop such that these issues can't happen anymore, but I haven't bothered at this point.