### PR TITLE
Nose-goes improvements

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -286,7 +286,7 @@ pub fn start_game_loop(
                     }
 
                     NoseGoes::InProgress { start_time, end_time, remaining_players } => {
-                        if now > end_time {
+                        if now > end_time || remaining_players.len() == 1 {
                             // Pick a random player to be the loser.
                             let loser = remaining_players
                             .iter()

--- a/www/client.css
+++ b/www/client.css
@@ -92,7 +92,7 @@ button {
     top: 0;
     left: 0;
 
-    background-color: rgba(0, 0, 0, 0.3);
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 #poison-marble {
@@ -100,7 +100,17 @@ button {
     height: 100px;
     border-radius: 50px;
 
+    transform: translate(-50%, -50%);
+
     position: absolute;
 
     background-color: red;
+}
+
+#poison-marble-text {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    white-space: nowrap;
 }

--- a/www/client.html
+++ b/www/client.html
@@ -63,7 +63,9 @@
                     v-if="noseGoes.showMarble"
                     v-bind:style="{ top: (noseGoes.marbleY * 100) + '%', left: (noseGoes.marbleX * 100) + '%' }"
                     v-on:click="poisonMarble"
-                ></div>
+                >
+                    <span id="poison-marble-text">Tap Me!</span>
+                </div>
             </div>
         </div>
 

--- a/www/client.html
+++ b/www/client.html
@@ -60,6 +60,7 @@
             <div id="nose-goes-overlay" v-if="noseGoes.isActive">
                 <div
                     id="poison-marble"
+                    v-if="noseGoes.showMarble"
                     v-bind:style="{ top: (noseGoes.marbleY * 100) + '%', left: (noseGoes.marbleX * 100) + '%' }"
                     v-on:click="poisonMarble"
                 ></div>

--- a/www/client.js
+++ b/www/client.js
@@ -79,8 +79,8 @@ socket.onmessage = function(event) {
     if (payload === 'BeginNoseGoes') {
         app.noseGoes.isActive = true;
         app.noseGoes.showMarble = true;
-        app.noseGoes.marbleX = Math.random();
-        app.noseGoes.marbleY = Math.random();
+        app.noseGoes.marbleX = Math.random() * 0.5 + 0.25;
+        app.noseGoes.marbleY = Math.random() * 0.5 + 0.25;
     } else if (payload['EndNoseGoes']) {
         // TODO: Do some kind of animation when the player is the one who lost?
         app.noseGoes.isActive = false;

--- a/www/client.js
+++ b/www/client.js
@@ -11,6 +11,7 @@ let app = new Vue({
         isPlaying: true,
         noseGoes: {
             isActive: false,
+            showMarble: true,
             marbleX: 0,
             marbleY: 0,
         },
@@ -49,18 +50,16 @@ let app = new Vue({
         },
 
         poisonMarble: function () {
+            this.noseGoes.showMarble = false;
             post(`/api/nose-goes/${this.id}`, {}, response => {
                 if (response === 'Survived') {
                     // TODO: What do we do if the player survived?
                 } else if (response === 'Died') {
                     // TODO: Do we handle the player's death now or what?
-                    app.isPlaying = false;
                 } else {
                     console.error('Unrecognized nose-goes result:', response);
                 }
             });
-
-            this.noseGoes.isActive = false;
         }
     },
 });
@@ -79,6 +78,7 @@ socket.onmessage = function(event) {
 
     if (payload === 'BeginNoseGoes') {
         app.noseGoes.isActive = true;
+        app.noseGoes.showMarble = true;
         app.noseGoes.marbleX = Math.random();
         app.noseGoes.marbleY = Math.random();
     } else if (payload['EndNoseGoes']) {


### PR DESCRIPTION
Various minor tweaks and improvements to the nose-goes mechanic to prepare it for testing at art review on Wednesday:

- End the nose-goes event early if enough players have tapped their poison marble.
- Don't allow players to tap/gain points while a nose-goes event is happening, even if they've tapped their poison marble.
- Hide the poison marble after the player taps it.
- Add a "Tap Me!" message to the poison marble on the player screen.
- Tweak the positioning of the poison marbles to make sure they always appear on screen.