### PR TITLE
Kill all remaining hippos at end of nose-goes event

### DIFF
--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -4,6 +4,7 @@
 //! one needs.
 
 use game::*;
+use std::collections::HashSet;
 use std::sync::*;
 use std::thread;
 use std::time::*;
@@ -42,13 +43,13 @@ pub enum HostBroadcast {
         duration: Duration,
 
         /// The players that are participating in the event.
-        players: Vec<PlayerId>,
+        players: HashSet<PlayerId>,
     },
 
-    /// A nose-goes event has ended, and a player has been knocked out.
+    /// A nose-goes event has ended, and one or more players have been knocked out.
     EndNoseGoes {
-        /// The player that got knocked out at the end of the event.
-        loser: PlayerId,
+        /// The players that have been knocked out. Will always have at least one member.
+        losers: HashSet<PlayerId>,
     },
 }
 
@@ -58,10 +59,10 @@ pub enum PlayerBroadcast {
     /// A nose-goes event has begun, and the player should be prompted to participate.
     BeginNoseGoes,
 
-    /// A nose-goes event has finished, and a player has been knocked out.
-    EndNoseGoes {
-        loser: PlayerId,
-    },
+    /// A nose-goes event has finished, and one or more playeres have been knocked out.
+    ///
+    /// One `PlayerLose` event will also be sent for each knocked-out player.
+    EndNoseGoes,
 
     /// A player has lost the game and has been removed.
     PlayerLose {

--- a/www/client.js
+++ b/www/client.js
@@ -81,7 +81,7 @@ socket.onmessage = function(event) {
         app.noseGoes.showMarble = true;
         app.noseGoes.marbleX = Math.random() * 0.5 + 0.25;
         app.noseGoes.marbleY = Math.random() * 0.5 + 0.25;
-    } else if (payload['EndNoseGoes']) {
+    } else if (payload === 'EndNoseGoes') {
         // TODO: Do some kind of animation when the player is the one who lost?
         app.noseGoes.isActive = false;
     } else if (payload['HippoEat']) {

--- a/www/host.js
+++ b/www/host.js
@@ -100,12 +100,14 @@ socket.onmessage = (event) => {
 
         TweenMax.fromTo(element, .2, from, to);
     } else if (payload['BeginNoseGoes']) {
-        let info = payload['BeginNoseGoes'];
         app.noseGoes.isActive = true;
     } else if (payload['EndNoseGoes']) {
-        let info = payload['EndNoseGoes'];
         app.noseGoes.isActive = false;
-        removePlayer(info.loser);
+
+        let info = payload['EndNoseGoes'];
+        for (let loser of info.losers) {
+            removePlayer(loser);
+        }
     } else {
         console.error('Unrecognized host event:', payload);
     }


### PR DESCRIPTION
This is the first part towards addressing the issue of players griefing by spawning huge numbers of hippos and crowding the screen. Now, at the end of each nose-goes event, all hippos that didn't clear the poison marble from their screen are knocked out. This limits abandoned hippos to cluttering the screen for no more than ~40 seconds (with the current nose-goes timing), which is a pretty reasonable kill time for players that have stopped paying attention to the game.

The other part of fixing the griefing issue is described in #19.