### PR TITLE
Persist player ID between refreshes

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -5,29 +5,30 @@ use rocket::http::Status;
 use rocket::response::*;
 use rocket::State;
 
-/// The response sent back from the `/register-player` endpoint.
+/// The current state for a player that is needed by the host site.
+///
+/// This doesn't include all of the player's internal state data, only the information needed
+/// by the display site.
 #[derive(Debug, Serialize, Responder)]
-pub struct RegisterPlayerResponse {
-    /// The `PlayerId` that was generated for the new player.
-    pub id: PlayerId,
+pub struct PlayerData {
+    /// The player's ID.
+    id: PlayerId,
 
-    /// The display name for the player.
-    pub name: String,
+    /// The player's display name.
+    name: String,
 
-    /// The player's starting score.
-    pub score: usize,
+    /// The player's current score.
+    score: usize,
 }
 
 /// Generates a `PlayerId` for a new player.
 // TODO: Allow players to specify a username when registering.
 #[get("/register-player")]
 pub fn register_player(
-    player_id_generator: State<PlayerIdGenerator>,
     players: State<PlayerMap>,
     broadcaster: State<HostBroadcaster>,
-) -> RegisterPlayerResponse
-{
-    let id = player_id_generator.next_id();
+) -> PlayerData {
+    let id = PlayerId::new();
     let name = game::generate_username();
 
     let player = Player {
@@ -51,7 +52,7 @@ pub fn register_player(
     });
 
     // Respond to the client.
-    RegisterPlayerResponse { id, name, score: 0 }
+    PlayerData { id, name, score: 0 }
 }
 
 /// The request expected from the client for the `/feed-me` endpoint.
@@ -143,22 +144,6 @@ pub fn nose_goes(
 #[derive(Debug, Serialize, Responder)]
 pub struct PlayersResponse {
     pub players: Vec<PlayerData>,
-}
-
-/// The current state for a player that is needed by the host site.
-///
-/// This doesn't include all of the player's internal state data, only the information needed
-/// by the display site.
-#[derive(Debug, Serialize, Responder)]
-pub struct PlayerData {
-    /// The player's ID.
-    id: PlayerId,
-
-    /// The player's display name.
-    name: String,
-
-    /// The player's current score.
-    score: usize,
 }
 
 #[get("/player/<id>")]

--- a/src/api.rs
+++ b/src/api.rs
@@ -149,7 +149,7 @@ pub struct PlayersResponse {
 ///
 /// This doesn't include all of the player's internal state data, only the information needed
 /// by the display site.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Responder)]
 pub struct PlayerData {
     /// The player's ID.
     id: PlayerId,
@@ -159,6 +159,17 @@ pub struct PlayerData {
 
     /// The player's current score.
     score: usize,
+}
+
+#[get("/player/<id>")]
+pub fn get_player(id: PlayerId, players: State<PlayerMap>) -> Option<PlayerData> {
+    let players = players.read().expect("Player map was poisoned!");
+
+    players.get(&id).map(|player| PlayerData {
+        id: player.id,
+        name: player.name.clone(),
+        score: player.score,
+    })
 }
 
 /// Returns a list of players and their scores.

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,12 +1,11 @@
 use broadcast::*;
-use rand::*;
+use rand::{self, Rng};
 use rocket::request::FromParam;
 use serde::*;
 use std::collections::{ HashMap, HashSet };
 use std::mem;
 use std::str::FromStr;
 use std::sync::*;
-use std::sync::atomic::*;
 use std::thread;
 use std::time::*;
 
@@ -24,6 +23,15 @@ use std::time::*;
 /// strings makes sense.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PlayerId(usize);
+
+impl PlayerId {
+    /// Generates a new, (probably) unique player ID.
+    ///
+    /// Player IDs are generated randomly in the u64 range. So they're probably unique. Probably.
+    pub fn new() -> PlayerId {
+        PlayerId(rand::random())
+    }
+}
 
 impl Serialize for PlayerId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
@@ -47,20 +55,6 @@ impl<'a> FromParam<'a> for PlayerId {
     fn from_param(param: &'a ::rocket::http::RawStr) -> Result<PlayerId, Self::Error> {
         let inner = param.as_str().parse()?;
         Ok(PlayerId(inner))
-    }
-}
-
-/// Generator for `PlayerId`.
-///
-/// Meant to be managed as application state by Rocket. Only one should ever be created, and Rocket
-/// ensures that only one can ever be registered as managed state.
-#[derive(Debug, Default)]
-pub struct PlayerIdGenerator(AtomicUsize);
-
-impl PlayerIdGenerator {
-    /// Generate a unique ID for a player.
-    pub fn next_id(&self) -> PlayerId {
-        PlayerId(self.0.fetch_add(1, Ordering::Relaxed))
     }
 }
 
@@ -212,7 +206,7 @@ pub fn generate_username() -> String {
         "Chi-town Potamus",
     ];
 
-    thread_rng().choose(NAMES).unwrap().to_string()
+    rand::thread_rng().choose(NAMES).unwrap().to_string()
 }
 
 /// The current state for a single player.

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,6 @@ fn main() {
             api::get_players,
             api::nose_goes,
         ])
-        .manage(PlayerIdGenerator::default())
         .manage(players)
         .manage(nose_goes)
         .manage(host_broadcaster)

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ fn static_serve_display() -> io::Result<NamedFile> {
 ///
 /// Any requests that aren't matched against an API route and aren't the special case `/` and `/host`
 /// routes will be served as static files, returning a 404 error if the file doesn't exist.
-#[get("/<file..>")]
+#[get("/<file..>", rank = 1)]
 fn static_serve(file: PathBuf) -> io::Result<NamedFile> {
     NamedFile::open(Path::new("www/").join(file))
 }
@@ -73,6 +73,7 @@ fn main() {
         .mount("/api", routes![
             api::register_player,
             api::feed_player,
+            api::get_player,
             api::get_players,
             api::nose_goes,
         ])

--- a/www/client.js
+++ b/www/client.js
@@ -95,6 +95,8 @@ socket.onmessage = function(event) {
         if (event.id === app.id) {
             app.score = event.score;
             app.isPlaying = false;
+
+            localStorage.removeItem('id');
         }
     } else {
         console.error('Unrecognized player event:', payload);
@@ -110,9 +112,31 @@ socket.onclose = function(event) {
     console.error('Socket closed I guess: ', event);
 };
 
-// Register the player with the backend.
-get('/api/register-player', response => {
-    app.id = response.id;
-    app.hippoName = response.name;
-    app.score = 0;
-});
+function registerPlayer() {
+    // Register the player with the backend.
+    get('/api/register-player', response => {
+        app.id = response.id;
+        app.hippoName = response.name;
+        app.score = response.score;
+
+        localStorage.setItem('id', response.id);
+    });
+}
+
+let cachedId = localStorage.getItem('id');
+if (cachedId != null) {
+    get(
+        `/api/player/${cachedId}`,
+        response => {
+            app.id = response.id;
+            app.hippoName = response.name;
+            app.score = response.score;
+        },
+
+        (error, status) => {
+            registerPlayer();
+        }
+    );
+} else {
+    registerPlayer();
+}

--- a/www/request.js
+++ b/www/request.js
@@ -1,22 +1,28 @@
 'use strict';
 
-function get(endpoint, onResponse) {
+function get(endpoint, onResponse, onError) {
     let request = new XMLHttpRequest();
     request.addEventListener('load', () => {
-        // TODO: Check the status code and handle any errors.
-        let response = JSON.parse(request.response);
-        onResponse(response);
+        if (request.status >= 200 && request.status < 300) {
+            let response = JSON.parse(request.response);
+            onResponse(response, request.status);
+        } else if (onError != null) {
+            onError(request.status);
+        }
     });
     request.open('GET', endpoint);
     request.send();
 }
 
-function post(endpoint, payload, onResponse) {
+function post(endpoint, payload, onResponse, onError) {
     let request = new XMLHttpRequest();
     request.addEventListener('load', () => {
-        // TODO: Check the status code and handle any errors.
-        let response = JSON.parse(request.response);
-        onResponse(response);
+        if (request.status >= 200 && request.status < 300) {
+            let response = JSON.parse(request.response);
+            onResponse(response, request.status);
+        } else if (onError != null) {
+            onError(request.status);
+        }
     });
     request.open('POST', endpoint);
     request.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');


### PR DESCRIPTION
The player site now caches the ID for the player, and will try to use the cached ID before generating a new one. This ensures that the player will keep their hippo (and their progress) if they refresh their page or close and reopen their browser. This follows up from #52 to drastically reduce the player's ability to grief the game. To reduce the chance of accidental collisions (as described in #19), the player IDs are now generated randomly. We likely don't have to worry about collisions, as there are 2<sup>64</sup> possible IDs.

Closes #19.