### PR TITLE
Player page makeover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "hangry-river-horse"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 name = "hangry-river-horse"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 rand = "0.3.15"

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,7 @@ use game::*;
 use rocket::http::Status;
 use rocket::response::*;
 use rocket::State;
+use std::mem;
 
 /// The current state for a player that is needed by the host site.
 ///
@@ -19,6 +20,9 @@ pub struct PlayerData {
 
     /// The player's current score.
     score: usize,
+
+    /// Whether or not the player has the crown (i.e. if the player is winning).
+    has_crown: bool,
 }
 
 /// Generates a `PlayerId` for a new player.
@@ -26,33 +30,43 @@ pub struct PlayerData {
 #[get("/register-player")]
 pub fn register_player(
     players: State<PlayerMap>,
-    broadcaster: State<HostBroadcaster>,
+    winner: State<Winner>,
+    host_broadcaster: State<HostBroadcaster>,
+    player_broadcaster: State<PlayerBroadcaster>,
 ) -> PlayerData {
     let id = PlayerId::new();
     let name = game::generate_username();
+    let score = 0;
 
     let player = Player {
         id,
         name: name.clone(),
-        score: 0,
+        score,
     };
 
     // Add the player to the game state.
-    {
-        let mut players = players.write().expect("Players map was poisoned!");
-        let old = players.insert(id, player);
-        assert!(old.is_none(), "Player ID was registered twice");
-    }
+    let mut players = players.write().expect("Players map was poisoned!");
+    let old = players.insert(id, player);
+    assert!(old.is_none(), "Player ID was registered twice");
 
     // Broadcast to all hosts that a new player has joined.
-    broadcaster.send(HostBroadcast::PlayerRegister {
+    host_broadcaster.send(HostBroadcast::PlayerRegister {
         id,
         name: name.clone(),
-        score: 0,
+        score,
     });
 
+    // Update winner if this is the first player.
+    let mut winner = winner.lock().expect("Winner was poisoned!");
+    let has_crown = winner.is_none();
+    if winner.is_none() {
+        *winner = Some(id);
+        host_broadcaster.send(HostBroadcast::UpdateWinner { id });
+        player_broadcaster.send(PlayerBroadcast::UpdateWinner { id });
+    }
+
     // Respond to the client.
-    PlayerData { id, name, score: 0 }
+    PlayerData { id, name, score, has_crown }
 }
 
 /// The request expected from the client for the `/feed-me` endpoint.
@@ -78,17 +92,19 @@ pub struct FeedMeResponse {
 pub fn feed_player(
     payload: FeedMeRequest,
     players: State<PlayerMap>,
-    broadcaster: State<HostBroadcaster>,
+    winner: State<Winner>,
+    host_broadcaster: State<HostBroadcaster>,
+    player_broadcaster: State<PlayerBroadcaster>,
 ) -> Result<FeedMeResponse> {
     let id = payload.id;
 
     // Add 1 to the player's score, returning the new score. We create an explicit scope here to
     // limit how long we hold the lock on the player map.
-    let score = {
-        let mut players = players.write().expect("Player map was poisoned");
+    let mut players = players.write().expect("Player map was poisoned!");
 
-        // Get the player's current score, or return an `InvalidPlayer` error if it's not in
-        // the scoreboard.
+    // Get the player's current score, or return an `InvalidPlayer` error if it's not in
+    // the scoreboard.
+    let score = {
         let player = players
             .get_mut(&id)
             .ok_or(Error::InvalidPlayer(id))?;
@@ -97,8 +113,19 @@ pub fn feed_player(
         player.score
     };
 
-    // Update the host displays and respond to the player.
-    broadcaster.send(HostBroadcast::HippoEat { id, score });
+    // Update the host displays.
+    host_broadcaster.send(HostBroadcast::HippoEat { id, score });
+
+    let mut winner = winner.lock().expect("Winner was poisoned!");
+    let winner = winner.as_mut().expect("There must be a winner if a hippo is being fed");
+    let winner_score = players.get(winner).unwrap().score;
+    if score > winner_score && id != *winner {
+        // Make the current player the new winner.
+        mem::replace(winner, id);
+        host_broadcaster.send(HostBroadcast::UpdateWinner { id });
+        player_broadcaster.send(PlayerBroadcast::UpdateWinner { id });
+    }
+
     Ok(FeedMeResponse { score })
 }
 
@@ -147,13 +174,19 @@ pub struct PlayersResponse {
 }
 
 #[get("/player/<id>")]
-pub fn get_player(id: PlayerId, players: State<PlayerMap>) -> Option<PlayerData> {
+pub fn get_player(
+    id: PlayerId,
+    players: State<PlayerMap>,
+    winner: State<Winner>,
+) -> Option<PlayerData> {
     let players = players.read().expect("Player map was poisoned!");
+    let winner = winner.lock().expect("Winner was poisoned!");
 
     players.get(&id).map(|player| PlayerData {
         id: player.id,
         name: player.name.clone(),
         score: player.score,
+        has_crown: Some(player.id) == *winner,
     })
 }
 
@@ -162,14 +195,16 @@ pub fn get_player(id: PlayerId, players: State<PlayerMap>) -> Option<PlayerData>
 /// This is used by new host connections to update thier display to match the current state of the
 /// game.
 #[get("/players")]
-pub fn get_players(players: State<PlayerMap>) -> PlayersResponse {
+pub fn get_players(players: State<PlayerMap>, winner: State<Winner>) -> PlayersResponse {
     let players = players.read().expect("Player map was poisoned!");
+    let winner = winner.lock().expect("Winner was poisoned!");
     let players = players.values()
         .map(|player| {
             PlayerData {
                 id: player.id,
                 name: player.name.clone(),
                 score: player.score,
+                has_crown: Some(player.id) == *winner,
             }
         })
         .collect();

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,6 @@ use game::*;
 use rocket::http::Status;
 use rocket::response::*;
 use rocket::State;
-use std::mem;
 
 /// The current state for a player that is needed by the host site.
 ///
@@ -121,7 +120,7 @@ pub fn feed_player(
     let winner_score = players.get(winner).unwrap().score;
     if score > winner_score && id != *winner {
         // Make the current player the new winner.
-        mem::replace(winner, id);
+        *winner = id;
         host_broadcaster.send(HostBroadcast::UpdateWinner { id });
         player_broadcaster.send(PlayerBroadcast::UpdateWinner { id });
     }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -52,6 +52,7 @@ pub enum HostBroadcast {
         losers: HashSet<PlayerId>,
     },
 
+    /// A new player has taken the lead.
     UpdateWinner {
         id: PlayerId,
     }
@@ -77,6 +78,7 @@ pub enum PlayerBroadcast {
         score: usize,
     },
 
+    /// A new player has taken the lead.
     UpdateWinner {
         id: PlayerId,
     }

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -51,6 +51,10 @@ pub enum HostBroadcast {
         /// The players that have been knocked out. Will always have at least one member.
         losers: HashSet<PlayerId>,
     },
+
+    UpdateWinner {
+        id: PlayerId,
+    }
 }
 
 /// A message to be broadcast to connected player clients.
@@ -72,6 +76,10 @@ pub enum PlayerBroadcast {
         /// The final score for the player that lost.
         score: usize,
     },
+
+    UpdateWinner {
+        id: PlayerId,
+    }
 }
 
 /// Broadcasts messages to websocket subscribers.

--- a/src/game.rs
+++ b/src/game.rs
@@ -58,6 +58,8 @@ impl<'a> FromParam<'a> for PlayerId {
     }
 }
 
+pub type Winner = Arc<Mutex<Option<PlayerId>>>;
+
 /// Generates a random username for new players.
 ///
 /// Names are chosen from a pre-written list of guaranteed-funny names.
@@ -230,6 +232,7 @@ pub type PlayerMap = Arc<RwLock<HashMap<PlayerId, Player>>>;
 pub fn start_game_loop(
     players: PlayerMap,
     nose_goes: NoseGoesState,
+    winner: Winner,
     host_broadcaster: HostBroadcaster,
     player_broadcaster: PlayerBroadcaster,
 ) {
@@ -282,7 +285,7 @@ pub fn start_game_loop(
                     NoseGoes::InProgress { start_time, end_time, remaining_players } => {
                         if now > end_time || remaining_players.len() == 1 {
                             // Remove the player from the player map.
-                            let mut players = players.write().expect("Player map was poisoned");
+                            let mut players = players.write().expect("Player map was poisoned!");
 
                             for loser in &remaining_players {
                                 let loser_info = players.remove(&loser).expect("Loser wasn't in player map");
@@ -291,6 +294,32 @@ pub fn start_game_loop(
                                     score: loser_info.score,
                                 });
                             }
+
+                            let mut winner = winner.lock().expect("Winner was poisoned!");
+                            let new_winner = players.iter()
+                                .fold(None, |winner, (id, player)| {
+                                    match winner {
+                                        Some((id, score)) => {
+                                            if player.score > score {
+                                                Some((id, player.score))
+                                            } else {
+                                                winner
+                                            }
+                                        }
+
+                                        None => { Some((id, player.score)) }
+                                    }
+                                })
+                                .map(|(&id, _)| id);
+
+                            if new_winner != *winner {
+                                if let Some(id) = new_winner {
+                                    host_broadcaster.send(HostBroadcast::UpdateWinner { id });
+                                    player_broadcaster.send(PlayerBroadcast::UpdateWinner { id });
+                                }
+                            }
+
+                            *winner = new_winner;
 
                             // Broadcast player loss to players and hosts.
                             host_broadcaster.send(HostBroadcast::EndNoseGoes { losers: remaining_players });

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,9 +56,11 @@ fn main() {
 
     let players = PlayerMap::default();
     let nose_goes = NoseGoesState::default();
+    let winner = Winner::default();
     game::start_game_loop(
         players.clone(),
         nose_goes.clone(),
+        winner.clone(),
         host_broadcaster.clone(),
         player_broadcaster.clone(),
     );
@@ -81,5 +83,6 @@ fn main() {
         .manage(nose_goes)
         .manage(host_broadcaster)
         .manage(player_broadcaster)
+        .manage(winner)
         .launch();
 }

--- a/www/client.css
+++ b/www/client.css
@@ -4,6 +4,9 @@ body {
     padding: 0;
     margin: 0;
     overflow: hidden;
+
+    background-color: #61a498;
+    background-image: url('assets/host_background.jpg');
 }
 
 h1 {
@@ -113,4 +116,44 @@ button {
     left: 50%;
     transform: translate(-50%, -50%);
     white-space: nowrap;
+}
+
+#hippo-root {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%, 40%);
+
+    z-index: -1;
+}
+
+.crown {
+    position: absolute;
+
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -60%);
+
+    width: 70%;
+}
+
+/* Crown animation configuration. */
+/* ============================== */
+
+.crown-enter-active {
+    transition: all 1s;
+}
+
+.crown-enter {
+    opacity: 0;
+    transform: translate(-50%, -300%);
+}
+
+.crown-leave-active {
+    transition: all 1s;
+}
+
+.crown-leave-to {
+    opacity: 0;
+    transform: translate(-50%, 50%);
 }

--- a/www/client.css
+++ b/www/client.css
@@ -22,8 +22,16 @@ body {
     text-align: center;
 }
 
+button {
+    font-family: 'Baloo', cursive;
+}
+
 h1 {
     font-size: 200%;
+}
+
+h2 {
+    font-size: 170%;
 }
 
 #app-root {
@@ -34,15 +42,23 @@ h1 {
     padding: 20px;
 }
 
-@media all and (orientation: portrait) {
+@media (orientation: portrait) {
     * {
         font-size: 5vw;
     }
+
+    #game-over-skull {
+        height: 70vw;
+    }
 }
 
-@media all and (orientation: landscape) {
+@media (orientation: landscape) {
     * {
         font-size: 5vh;
+    }
+
+    #game-over-skull {
+        height: 70vh;
     }
 }
 
@@ -55,8 +71,11 @@ h1 {
     width: calc(100% - 40px);
 }
 
-#hippo-name {
+.hippo-name {
     color: #bc00a6;
+}
+
+#name {
     font-size: 170%
 }
 
@@ -73,6 +92,10 @@ h1 {
     font-size: 150%;
 }
 
+#lose-screen h2 {
+    margin: 0;
+}
+
 #game-over-text {
     font-size: 200%;
 }
@@ -81,14 +104,21 @@ h1 {
     padding-bottom: 30px;
 }
 
+#game-over-skull {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: -10;
+}
+
 button {
     background-color: #bc00a6;
     color: white;
     border-style: none;
     padding: 20px;
-    border-radius: 5px;
+    border-radius: 15px;
 }
-
 
 #nose-goes-overlay {
     width: 100vw;
@@ -144,7 +174,7 @@ button {
 /* Score animation configuration. */
 /* ============================== */
 
-#score-text {
+.score-enter-active {
     transition: all 0.2s;
 }
 
@@ -155,6 +185,18 @@ button {
 
 .score-leave-active {
     display: none;
+}
+
+/* Hippo head animation configuration. */
+/* =================================== */
+
+.hippo-leave-active {
+    transition: all 1s;
+}
+
+#hippo-root.hippo-leave-to {
+    opacity: 0;
+    transform: translate(-50%, 100%);
 }
 
 /* Crown animation configuration. */
@@ -176,4 +218,16 @@ button {
 .crown-leave-to {
     opacity: 0;
     transform: translate(-50%, 50%);
+}
+
+/* Skull animation configuration. */
+/* ============================== */
+
+.skull-enter-active {
+    transition: all 3s;
+}
+
+#game-over-skull.skull-enter {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(3);
 }

--- a/www/client.css
+++ b/www/client.css
@@ -7,23 +7,8 @@ body {
 
     background-color: #61a498;
     background-image: url('assets/host_background.jpg');
-}
 
-h1 {
-    margin: 0;
-}
-
-h2 {
-    margin: 0;
-}
-
-#app-root {
-    width: 100vw;
-    height: 100vh;
-    box-sizing: border-box;
-
-    overflow: hidden;
-
+    /* Disable text selection so the user doesn't accidentally highlight text while tapping. */
     -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */
     -khtml-user-select: none; /* Konqueror HTML */
@@ -31,8 +16,20 @@ h2 {
     -ms-user-select: none; /* Internet Explorer/Edge */
     user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
 
+    overflow: hidden;
+
     font-family: 'Baloo', cursive;
     text-align: center;
+}
+
+h1 {
+    font-size: 200%;
+}
+
+#app-root {
+    width: 100vw;
+    height: 100vh;
+    box-sizing: border-box;
 
     padding: 20px;
 }
@@ -58,8 +55,18 @@ h2 {
     width: calc(100% - 40px);
 }
 
+#hippo-name {
+    color: #bc00a6;
+    font-size: 170%
+}
+
 #tap-text {
     font-size: 200%;
+}
+
+#score-text {
+    color: #bc00a6;
+    font-size: 170%;
 }
 
 #lose-screen {
@@ -82,9 +89,6 @@ button {
     border-radius: 5px;
 }
 
-.hippo-name {
-    color: #bc00a6;
-}
 
 #nose-goes-overlay {
     width: 100vw;
@@ -135,6 +139,22 @@ button {
     transform: translate(-50%, -60%);
 
     width: 70%;
+}
+
+/* Score animation configuration. */
+/* ============================== */
+
+#score-text {
+    transition: all 0.2s;
+}
+
+.score-enter {
+    opacity: 0;
+    transform: scale(3);
+}
+
+.score-leave-active {
+    display: none;
 }
 
 /* Crown animation configuration. */

--- a/www/client.css
+++ b/www/client.css
@@ -47,6 +47,11 @@ h2 {
         font-size: 5vw;
     }
 
+    #poison-marble, #poison-marble-flash {
+        width: 20vw;
+        height: 20vw;
+    }
+
     #game-over-skull {
         height: 70vw;
     }
@@ -55,6 +60,11 @@ h2 {
 @media (orientation: landscape) {
     * {
         font-size: 5vh;
+    }
+
+    #poison-marble, #poison-marble-flash {
+        width: 20vh;
+        height: 20vh;
     }
 
     #game-over-skull {
@@ -132,16 +142,18 @@ button {
     background-color: rgba(0, 0, 0, 0.5);
 }
 
-#poison-marble {
-    width: 100px;
-    height: 100px;
-    border-radius: 50px;
-
-    transform: translate(-50%, -50%);
+#poison-marble, #poison-marble-flash {
+    border-radius: 50%;
 
     position: absolute;
+    transform: translate(-50%, -50%);
 
     background-color: red;
+    color: white;
+}
+
+#poison-marble {
+    z-index: 1;
 }
 
 #poison-marble-text {
@@ -190,8 +202,12 @@ button {
 /* Hippo head animation configuration. */
 /* =================================== */
 
-.hippo-leave-active {
+.hippo-enter-active, .hippo-leave-active {
     transition: all 1s;
+}
+
+#hippo-root.hippo-enter {
+    transform: translate(-50%, 100%);
 }
 
 #hippo-root.hippo-leave-to {

--- a/www/client.html
+++ b/www/client.html
@@ -62,18 +62,24 @@
                 <button v-on:click.stop="reload">Play Again</button>
             </div>
 
-            <div id="nose-goes-overlay" v-if="noseGoes.isActive">
+            <div id="nose-goes-overlay" v-show="noseGoes.isActive">
                 <div
                     id="poison-marble"
-                    v-if="noseGoes.showMarble"
+                    v-show="noseGoes.showMarble"
                     v-bind:style="{ top: (noseGoes.marbleY * 100) + '%', left: (noseGoes.marbleX * 100) + '%' }"
                     v-on:click="poisonMarble"
                 >
                     <span id="poison-marble-text">Tap Me!</span>
                 </div>
+                <div
+                    id="poison-marble-flash"
+                    v-show="noseGoes.showMarble"
+                    v-bind:style="{ top: (noseGoes.marbleY * 100) + '%', left: (noseGoes.marbleX * 100) + '%' }"
+                >
+                </div>
             </div>
 
-            <transition appear name="hippo">
+            <transition name="hippo" appear>
                 <div id="hippo-root" v-if="isPlaying">
                     <img class="head" src="assets/hippo.png">
                     <transition name="crown">

--- a/www/client.html
+++ b/www/client.html
@@ -45,7 +45,7 @@
             <h1>HungryHipp.us</h1>
 
             <div id="game-screen" class="screen" v-if="isPlaying">
-                <div id="hippo-name">{{ hippoName }}</div>
+                <div id="name" class="hippo-name">{{ hippoName }}</div>
                 <div id="tap-text">Tap anywhere!</div>
                 <transition name="score">
                     <div id="score-text" :key="score">{{ score }}</div>
@@ -53,7 +53,10 @@
             </div>
 
             <div id="lose-screen" class="screen" v-if="!isPlaying">
-                <h2 id="game-over-text">Game Over</h2>
+                <h2>Game Over</h2>
+                <transition appear name="skull">
+                    <img id="game-over-skull" src="assets/skull.png">
+                </transition>
                 <div id="game-over-message">Your hippo <span class="hippo-name">{{ hippoName }}</span> ate a poison marble and died.</div>
                 <div id="final-score-text">Your final score is {{ score }}.</div>
                 <button v-on:click.stop="reload">Play Again</button>
@@ -70,12 +73,14 @@
                 </div>
             </div>
 
-            <div id="hippo-root" v-if="isPlaying">
-                <img class="head" src="assets/hippo.png">
-                <transition name="crown">
-                    <img class="crown" src="assets/crown.png" v-if="hasCrown">
-                </transition>
-            </div>
+            <transition appear name="hippo">
+                <div id="hippo-root" v-if="isPlaying">
+                    <img class="head" src="assets/hippo.png">
+                    <transition name="crown">
+                        <img class="crown" src="assets/crown.png" v-if="hasCrown">
+                    </transition>
+                </div>
+            </transition>
         </div>
 
         <!-- Load script for the client. -->

--- a/www/client.html
+++ b/www/client.html
@@ -45,9 +45,11 @@
             <h1>HungryHipp.us</h1>
 
             <div id="game-screen" class="screen" v-if="isPlaying">
-                <h2 class="hippo-name">{{ hippoName }}</h2>
+                <div id="hippo-name">{{ hippoName }}</div>
                 <div id="tap-text">Tap anywhere!</div>
-                <div id="score-text">Score: {{ score }}</div>
+                <transition name="score">
+                    <div id="score-text" :key="score">{{ score }}</div>
+                </transition>
             </div>
 
             <div id="lose-screen" class="screen" v-if="!isPlaying">
@@ -68,7 +70,7 @@
                 </div>
             </div>
 
-            <div id="hippo-root">
+            <div id="hippo-root" v-if="isPlaying">
                 <img class="head" src="assets/hippo.png">
                 <transition name="crown">
                     <img class="crown" src="assets/crown.png" v-if="hasCrown">

--- a/www/client.html
+++ b/www/client.html
@@ -46,7 +46,7 @@
 
             <div id="game-screen" class="screen" v-if="isPlaying">
                 <h2 class="hippo-name">{{ hippoName }}</h2>
-                <div id="tap-text">Tap anywhere to feed your hippo!</div>
+                <div id="tap-text">Tap anywhere!</div>
                 <div id="score-text">Score: {{ score }}</div>
             </div>
 
@@ -66,6 +66,13 @@
                 >
                     <span id="poison-marble-text">Tap Me!</span>
                 </div>
+            </div>
+
+            <div id="hippo-root">
+                <img class="head" src="assets/hippo.png">
+                <transition name="crown">
+                    <img class="crown" src="assets/crown.png" v-if="hasCrown">
+                </transition>
             </div>
         </div>
 

--- a/www/client.js
+++ b/www/client.js
@@ -36,13 +36,13 @@ let app = new Vue({
                 '#tap-text',
                 0.1,
                 { scale: 1 },
-                { scale: 1.2, yoyo: true, repeat: 1 },
+                { scale: 1.5, yoyo: true, repeat: 1 },
             );
             TweenMax.fromTo(
                 '#tap-text',
                 0.1,
                 { rotation: 0 },
-                { rotation: Math.random() * 6 - 3, yoyo: true, repeat: 1 },
+                { rotation: Math.random() * 10 - 5, yoyo: true, repeat: 1 },
             );
         },
 

--- a/www/client.js
+++ b/www/client.js
@@ -82,6 +82,8 @@ socket.onmessage = function(event) {
         app.noseGoes.showMarble = true;
         app.noseGoes.marbleX = Math.random() * 0.5 + 0.25;
         app.noseGoes.marbleY = Math.random() * 0.5 + 0.25;
+
+        window.navigator.vibrate([300, 30, 500, 30, 300]);
     } else if (payload === 'EndNoseGoes') {
         // TODO: Do some kind of animation when the player is the one who lost?
         app.noseGoes.isActive = false;

--- a/www/client.js
+++ b/www/client.js
@@ -99,6 +99,9 @@ socket.onmessage = function(event) {
 
             localStorage.removeItem('id');
         }
+    } else if (payload['UpdateWinner']) {
+        let event = payload['UpdateWinner'];
+        app.hasCrown = (event.id == app.id);
     } else {
         console.error('Unrecognized player event:', payload);
     }
@@ -119,6 +122,7 @@ function registerPlayer() {
         app.id = response.id;
         app.hippoName = response.name;
         app.score = response.score;
+        app.hasCrown = response.has_crown;
 
         localStorage.setItem('id', response.id);
     });
@@ -132,6 +136,7 @@ if (cachedId != null) {
             app.id = response.id;
             app.hippoName = response.name;
             app.score = response.score;
+            app.hasCrown = response.has_crown;
         },
 
         (error, status) => {

--- a/www/client.js
+++ b/www/client.js
@@ -146,3 +146,22 @@ if (cachedId != null) {
 } else {
     registerPlayer();
 }
+
+// Start the poison marble fidget animation.
+let poisonMarbleElement = document.getElementById('poison-marble');
+TweenMax.to(poisonMarbleElement, 0.13, { scale: 1.3, repeat: -1, yoyo: true });
+TweenMax.fromTo(
+    poisonMarbleElement,
+    0.1,
+    { rotation: -4 },
+    { rotation: 4, repeat: -1, yoyo: true },
+);
+
+// Start the poison marble flash animation.
+let poisonMarbleFlashElement = document.getElementById('poison-marble-flash');
+TweenMax.fromTo(
+    poisonMarbleFlashElement,
+    3,
+    { scale: 1, opacity: 1 },
+    { scale: 3, opacity: 0, repeat: -1 },
+);

--- a/www/client.js
+++ b/www/client.js
@@ -9,6 +9,7 @@ let app = new Vue({
         hippoName: null,
         score: null,
         isPlaying: true,
+        hasCrown: false,
         noseGoes: {
             isActive: false,
             showMarble: true,


### PR DESCRIPTION
I've made a variety of improvements to the player site to make it look all good an not bad (or at least not as bad as it used to):

- The background of the player page now uses the same pattern as the host page.
- Increased the size of most of the text to make things easier to see.
- Change the tap tap text to just say "Tap anywhere!".
- Have the player's hippo peak out from the bottom of the screen.
- If the player is winning, their hippo on their phone gets a crown.
- Make sure the "Tap me!" text stays inside the poison marble.
- Add a fidget animation to the poison marble, and a pulse animation.
- Have the player's phone vibrate when a nose-goes event starts.