### PR TITLE
Nose goes bonus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target/
 **/*.rs.bk
+
+# IntelliJ IDEA
+.idea
+hangry-hippos.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-- nightly
+- nightly-2017-08-13
 cache: cargo
 script:
 - cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,13 +2,13 @@
 name = "hangry-river-horse"
 version = "0.5.0"
 dependencies = [
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_contrib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_derive 0.3.0 (git+https://github.com/excaliburHisSheath/rocket_derive)",
- "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -31,13 +31,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -59,6 +64,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cookie"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +81,11 @@ dependencies = [
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dtoa"
@@ -127,7 +145,7 @@ name = "iovec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -137,7 +155,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -167,18 +185,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazycell"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.26"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "magenta"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "magenta-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "matches"
@@ -190,7 +225,7 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -203,16 +238,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -223,19 +260,19 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "net2"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -250,7 +287,7 @@ name = "num_cpus"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -280,10 +317,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -302,14 +340,14 @@ dependencies = [
  "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.26"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -319,14 +357,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -339,34 +377,34 @@ dependencies = [
  "ordermap 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear_codegen 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "state 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "yansi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "yansi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_contrib"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -391,12 +429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -421,7 +459,7 @@ dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -436,7 +474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -468,17 +506,17 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -553,11 +591,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -574,17 +612,20 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30e93c03064e7590d0466209155251b90c22e37fab1daf2771582598b5827557"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
-"checksum bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b24f16593f445422331a5eed46b72f7f171f910fead4f2ea8f17e727e9c5c14"
+"checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
+"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum cookie 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa6d675d62b2f95b56b331b5222a520149a54f23a2d21974dfcc69caf0a9d"
+"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
@@ -598,15 +639,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
-"checksum libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "30885bcb161cf67054244d10d4a7f4835ffd58773bc72e07d35fecf472295503"
+"checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
+"checksum libc 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "8a014d9226c2cc402676fbe9ea2e15dd5222cd1dd57f576b5b283178c944a264"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
+"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
+"checksum mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "dbd91d3bfbceb13897065e97b2ef177a09a438cb33612b2d371bf568819a9313"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "94101fd932816f97eb9a5116f6c1a11511a1fed7db21c5ccd823b2dc11abf566"
+"checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
 "checksum ordermap 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c036a53e6bb62d7eee2edf7e087df56fd84c7bbae6a0bd93c2b9f54bddf62e03"
@@ -614,29 +657,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pear_codegen 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0455b67d07b3aa40a552256059f11eb8db3a848cbec81bae3e3cb366e6e74e24"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
-"checksum redox_syscall 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "9df6a71a1e67be2104410736b2389fb8e383c1d7e9e792d629ff13c02867147a"
+"checksum redox_syscall 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "8312fba776a49cf390b7b62f3135f9b294d8617f7a7592cfd0ac2492b658cd7b"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
-"checksum rocket 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13c578f7f69f2ee0906fc95c2fedc1433a185e46c7be0e6a59b91222fb36a7fc"
-"checksum rocket_codegen 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94b8d869c119c23b150568f4184b658a108cabd964cc797d78823f6c1b802202"
-"checksum rocket_contrib 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5acf2c142e8fa077b9bd881834c9906781cd76e997d2d788e2bfbeef110e9e0a"
+"checksum rocket 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "effada3a39c68751228fcaf7bc03eb9231a61c38b60861deedb2a5ab68f25030"
+"checksum rocket_codegen 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d741bfd93295acad131d3e8a458b8058fd8d6b4bd84b3139a78952bddc5b0b56"
+"checksum rocket_contrib 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f52009379ac442d63eacfb64ca03b0bea0ed5a406b65888915041e85ca8f9ec0"
 "checksum rocket_derive 0.3.0 (git+https://github.com/excaliburHisSheath/rocket_derive)" = "<none>"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
-"checksum serde 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "433d7d9f8530d5a939ad5e0e72a6243d2e42a24804f70bf592c679363dcacb2f"
-"checksum serde_derive 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "7b707cf0d4cab852084f573058def08879bb467fda89d99052485e7d00edd624"
+"checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
+"checksum serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cf823e706be268e73e7747b147aa31c8f633ab4ba31f115efb57e5047c3a76dd"
 "checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
 "checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
-"checksum smallvec 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "26aa2afb825226fa29f0315de04d5a4af5fd44adadf837296accc01a49929724"
+"checksum smallvec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5864faef64ccadecaafebd8d57ae1b27ce8190c8c491d4a284400bb6fa639ae"
 "checksum state 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3205ddf193c68751abcb17262a430c4c32f0d4cdc6b7f7c8915db442b9579012"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
-"checksum toml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b0601da6c97135c8d330c7a13a013ca6cd4143221b01de2f8d4edc50a9e551c7"
+"checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
@@ -650,4 +693,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89c48c53bf9dee34411a08993c10b879c36e105d609b46e25673befe3a5c1320"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum yansi 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b731f15b7c13b4988f2836d88ce92b699c72dbc0178cf9d7c3ecad0d8fd1c902"
+"checksum yansi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8200521fa88cba2d4ec8d7500616a284ae8bd92d492a309773478a870660573a"

--- a/src/api.rs
+++ b/src/api.rs
@@ -138,6 +138,7 @@ pub enum NoseGoesResponse {
 pub fn nose_goes(
     id: PlayerId,
     nose_goes: State<NoseGoesState>,
+    winner: State<Winner>,
 ) -> Result<NoseGoesResponse> {
     let mut nose_goes = nose_goes.lock().expect("Nose-goes state was poisoned!");
     match *nose_goes {
@@ -145,7 +146,9 @@ pub fn nose_goes(
             Err(Error::InvalidNoesGoes)
         }
 
-        NoseGoes::InProgress { ref mut remaining_players, .. } => {
+        NoseGoes::InProgress { ref mut remaining_players, ref mut bonus_winner, .. } => {
+            let winner = winner.lock().expect("Winner was poisoned!");
+
             // It's an error for the player to not be part of the nose-goes event.
             if !remaining_players.contains(&id) {
                 return Err(Error::InvalidNoesGoes);
@@ -155,6 +158,12 @@ pub fn nose_goes(
             // is the last one left, they die.
             if remaining_players.len() > 1 {
                 remaining_players.remove(&id);
+
+                // If the player is not winning and first one to tap, they get the bonus points.
+                if bonus_winner.is_none() && *winner != Some(id) {
+                    *bonus_winner = Some(id);
+                }
+
                 Ok(NoseGoesResponse::Survived)
             } else {
                 Ok(NoseGoesResponse::Died)

--- a/src/api.rs
+++ b/src/api.rs
@@ -139,6 +139,8 @@ pub fn nose_goes(
     id: PlayerId,
     nose_goes: State<NoseGoesState>,
     winner: State<Winner>,
+    host_broadcaster: State<HostBroadcaster>,
+    player_broadcaster: State<PlayerBroadcaster>,
 ) -> Result<NoseGoesResponse> {
     let mut nose_goes = nose_goes.lock().expect("Nose-goes state was poisoned!");
     match *nose_goes {
@@ -162,6 +164,10 @@ pub fn nose_goes(
                 // If the player is not winning and first one to tap, they get the bonus points.
                 if bonus_winner.is_none() && *winner != Some(id) {
                     *bonus_winner = Some(id);
+
+                    // Notify the player and host that a bonus winner has been selected.
+                    host_broadcaster.send(HostBroadcast::BonusWinner { id });
+                    player_broadcaster.send(PlayerBroadcast::BonusWinner { id });
                 }
 
                 Ok(NoseGoesResponse::Survived)

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -50,20 +50,25 @@ pub enum HostBroadcast {
     EndNoseGoes {
         /// The players that have been knocked out. Will always have at least one member.
         losers: HashSet<PlayerId>,
+
+        /// The player that won the bonus points in the nose-goes round, if any.
+        ///
+        /// The first element of the tuple is the ID of the bonus winner, and the second element
+        /// is the player's new score.
         bonus_winner: Option<(PlayerId, usize)>
     },
 
     /// A new player has taken the lead.
     UpdateWinner {
         id: PlayerId,
-    }
+    },
 }
 
 /// A message to be broadcast to connected player clients.
 #[derive(Debug, Serialize)]
 pub enum PlayerBroadcast {
     /// A nose-goes event has begun, and the player should be prompted to participate.
-    BeginNoseGoes {}
+    BeginNoseGoes {},
 
     /// A nose-goes event has finished, and one or more playeres have been knocked out.
     ///
@@ -84,7 +89,7 @@ pub enum PlayerBroadcast {
     /// A new player has taken the lead.
     UpdateWinner {
         id: PlayerId,
-    }
+    },
 }
 
 /// Broadcasts messages to websocket subscribers.

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -46,6 +46,11 @@ pub enum HostBroadcast {
         players: HashSet<PlayerId>,
     },
 
+    /// The first player to tap during a nose-goes event has been selected to earn bonus points.
+    BonusWinner {
+        id: PlayerId,
+    },
+
     /// A nose-goes event has ended, and one or more players have been knocked out.
     EndNoseGoes {
         /// The players that have been knocked out. Will always have at least one member.
@@ -69,6 +74,11 @@ pub enum HostBroadcast {
 pub enum PlayerBroadcast {
     /// A nose-goes event has begun, and the player should be prompted to participate.
     BeginNoseGoes {},
+
+    /// The first player to tap during a nose-goes event has been selected to earn bonus points.
+    BonusWinner {
+        id: PlayerId,
+    },
 
     /// A nose-goes event has finished, and one or more playeres have been knocked out.
     ///

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -50,6 +50,7 @@ pub enum HostBroadcast {
     EndNoseGoes {
         /// The players that have been knocked out. Will always have at least one member.
         losers: HashSet<PlayerId>,
+        bonus_winner: Option<(PlayerId, usize)>
     },
 
     /// A new player has taken the lead.
@@ -62,12 +63,14 @@ pub enum HostBroadcast {
 #[derive(Debug, Serialize)]
 pub enum PlayerBroadcast {
     /// A nose-goes event has begun, and the player should be prompted to participate.
-    BeginNoseGoes,
+    BeginNoseGoes {}
 
     /// A nose-goes event has finished, and one or more playeres have been knocked out.
     ///
     /// One `PlayerLose` event will also be sent for each knocked-out player.
-    EndNoseGoes,
+    EndNoseGoes {
+        bonus_winner: Option<(PlayerId, usize)>
+    },
 
     /// A player has lost the game and has been removed.
     PlayerLose {

--- a/src/game.rs
+++ b/src/game.rs
@@ -281,6 +281,7 @@ pub fn start_game_loop(
                                     start_time: next_start_time,
                                     end_time: next_start_time + nose_goes_duration,
                                     remaining_players,
+                                    bonus_winner: None,
                                 }
                             } else {
                                 // There aren't enough players to run the nose-goes event. Delay until
@@ -293,9 +294,9 @@ pub fn start_game_loop(
                         }
                     }
 
-                    NoseGoes::InProgress { start_time, end_time, remaining_players } => {
+                    NoseGoes::InProgress { start_time, end_time, remaining_players, bonus_winner } => {
                         if now > end_time || remaining_players.len() == 1 {
-                            // Remove the player from the player map.
+                            // Remove all players who haven't tapped from the players map.
                             let mut players = players.write().expect("Player map was poisoned!");
                             for loser in &remaining_players {
                                 let loser_info = players.remove(&loser).expect("Loser wasn't in player map");
@@ -338,7 +339,12 @@ pub fn start_game_loop(
 
                             NoseGoes::Inactive { next_start_time: end_time + nose_goes_interval }
                         } else {
-                            NoseGoes::InProgress { start_time, end_time, remaining_players }
+                            NoseGoes::InProgress {
+                                start_time,
+                                end_time,
+                                remaining_players,
+                                bonus_winner,
+                            }
                         }
                     }
                 };
@@ -360,6 +366,7 @@ pub enum NoseGoes {
         start_time: Instant,
         end_time: Instant,
         remaining_players: HashSet<PlayerId>,
+        bonus_winner: Option<PlayerId>,
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -300,7 +300,6 @@ pub fn start_game_loop(
                             // Remove all players who haven't tapped from the players map.
                             let mut players = players.write().expect("Player map was poisoned!");
                             let mut bonus = 0;
-                            let min_bonus = remaining_players.len() * 100;
                             for loser in &remaining_players {
                                 let loser_info = players.remove(&loser).expect("Loser wasn't in player map");
                                 player_broadcaster.send(PlayerBroadcast::PlayerLose {
@@ -308,10 +307,8 @@ pub fn start_game_loop(
                                     score: loser_info.score,
                                 });
 
-                                bonus += loser_info.score;
+                                bonus += cmp::max(loser_info.score, 100);
                             }
-
-                            let bonus = cmp::max(bonus, min_bonus);
 
                             // Apply bonus points to the bonus winner, if any.
                             let bonus_winner = match bonus_winner {

--- a/src/game.rs
+++ b/src/game.rs
@@ -2,6 +2,7 @@ use broadcast::*;
 use rand::{self, Rng};
 use rocket::request::FromParam;
 use serde::*;
+use std::cmp;
 use std::collections::{ HashMap, HashSet };
 use std::mem;
 use std::str::FromStr;
@@ -275,7 +276,7 @@ pub fn start_game_loop(
                                     duration: nose_goes_duration,
                                     players: remaining_players.clone(),
                                 });
-                                player_broadcaster.send(PlayerBroadcast::BeginNoseGoes);
+                                player_broadcaster.send(PlayerBroadcast::BeginNoseGoes {});
 
                                 NoseGoes::InProgress {
                                     start_time: next_start_time,
@@ -298,13 +299,29 @@ pub fn start_game_loop(
                         if now > end_time || remaining_players.len() == 1 {
                             // Remove all players who haven't tapped from the players map.
                             let mut players = players.write().expect("Player map was poisoned!");
+                            let mut bonus = 0;
+                            let min_bonus = remaining_players.len() * 100;
                             for loser in &remaining_players {
                                 let loser_info = players.remove(&loser).expect("Loser wasn't in player map");
                                 player_broadcaster.send(PlayerBroadcast::PlayerLose {
                                     id: *loser,
                                     score: loser_info.score,
                                 });
+
+                                bonus += loser_info.score;
                             }
+
+                            let bonus = cmp::max(bonus, min_bonus);
+
+                            // Apply bonus points to the bonus winner, if any.
+                            let bonus_winner = match bonus_winner {
+                                Some(bonus_winner) => {
+                                    let bonus_winner = players.get_mut(&bonus_winner).expect("Bonus winner wasn't in players map");
+                                    bonus_winner.score += bonus;
+                                    Some((bonus_winner.id, bonus_winner.score))
+                                },
+                                None => None,
+                            };
 
                             // Recalculate the new winner after all losers have been removed.
                             let mut winner = winner.lock().expect("Winner was poisoned!");
@@ -334,8 +351,11 @@ pub fn start_game_loop(
                             *winner = new_winner;
 
                             // Broadcast player loss to players and hosts.
-                            host_broadcaster.send(HostBroadcast::EndNoseGoes { losers: remaining_players });
-                            player_broadcaster.send(PlayerBroadcast::EndNoseGoes);
+                            host_broadcaster.send(HostBroadcast::EndNoseGoes {
+                                losers: remaining_players,
+                                bonus_winner,
+                            });
+                            player_broadcaster.send(PlayerBroadcast::EndNoseGoes { bonus_winner });
 
                             NoseGoes::Inactive { next_start_time: end_time + nose_goes_interval }
                         } else {

--- a/www/client.js
+++ b/www/client.js
@@ -77,15 +77,21 @@ socket.onmessage = function(event) {
     // TODO: Do some kind of validation.
     let payload = JSON.parse(event.data);
 
-    if (payload === 'BeginNoseGoes') {
+    if (payload['BeginNoseGoes']) {
         app.noseGoes.isActive = true;
         app.noseGoes.showMarble = true;
         app.noseGoes.marbleX = Math.random() * 0.5 + 0.25;
         app.noseGoes.marbleY = Math.random() * 0.5 + 0.25;
 
         window.navigator.vibrate([300, 30, 500, 30, 300]);
-    } else if (payload === 'EndNoseGoes') {
+    } else if (payload['EndNoseGoes']) {
         // TODO: Do some kind of animation when the player is the one who lost?
+        let event = payload['EndNoseGoes'];
+        console.log(event);
+        if (event.bonus_winner != null && event.bonus_winner[0] === app.id) {
+            app.score = event.bonus_winner[1];
+        }
+
         app.noseGoes.isActive = false;
     } else if (payload['HippoEat']) {
         let event = payload['HippoEat'];

--- a/www/client.js
+++ b/www/client.js
@@ -84,6 +84,11 @@ socket.onmessage = function(event) {
         app.noseGoes.marbleY = Math.random() * 0.5 + 0.25;
 
         window.navigator.vibrate([300, 30, 500, 30, 300]);
+    } else if (payload['BonusWinner']) {
+        let event = payload['BonusWinner'];
+        if (event.id === app.id) {
+            // TODO: Show that we're the bonus winner.
+        }
     } else if (payload['EndNoseGoes']) {
         // TODO: Do some kind of animation when the player is the one who lost?
         let event = payload['EndNoseGoes'];

--- a/www/host.css
+++ b/www/host.css
@@ -77,6 +77,9 @@ body {
 }
 
 .hippo-head-root {
+    /* Use relative positioning so that we can absolutely position children. */
+    position: relative;
+
     /* We use flexbox to position the label on the outside and the hippo head on the inside. */
     display: flex;
 
@@ -168,6 +171,25 @@ body {
     background-size: 60px;
     background-position: center;
     background-repeat: no-repeat;
+}
+
+#bonus-text-root {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+#bonus-text {
+    position: relative;
+
+    font-size: 200%;
+    white-space: nowrap;
+
+    color: #bc00a6;
+    background-color: rgba(255, 255, 255, 0.9);
+    border-radius: 10px;
+    padding: 0 10px;
 }
 
 /* Top side styles. */
@@ -319,4 +341,16 @@ body {
 .crown-leave-to {
     opacity: 0;
     transform: translate(-50%, 50%);
+}
+
+/* Bonus text animation configuration. */
+/* =================================== */
+
+.bonus-text-enter-active {
+    transition: all 0.3s;
+}
+
+#bonus-text-root.bonus-text-enter {
+    opacity: 0;
+    transform: translate(-50%, -50%) rotate(180deg) scale(3);
 }

--- a/www/host.js
+++ b/www/host.js
@@ -113,6 +113,11 @@ socket.onmessage = (event) => {
         for (let loser of info.losers) {
             removePlayer(loser);
         }
+
+        if (info.bonus_winner != null) {
+            let bonusWinner = app.hippoMap[info.bonus_winner[0]];
+            bonusWinner.player.score = info.bonus_winner[1];
+        }
     } else if (payload['UpdateWinner']) {
         for (let key in app.hippoMap) {
             let hippo = app.hippoMap[key];

--- a/www/host.js
+++ b/www/host.js
@@ -53,6 +53,11 @@ Vue.component('hippo-head', {
         <transition name="poison">
             <div class="poison-pill" :id="'poison-' + hippo.player.id" v-if="hippo.isDead"></div>
         </transition>
+        <transition name="bonus-text">
+            <div id="bonus-text-root" v-if="hippo.wonBonus">
+                <div id="bonus-text">Speedy Bonus!</div>
+            </div>
+        </transition>
     </div>
     `,
 });
@@ -60,7 +65,7 @@ Vue.component('hippo-head', {
 // Helpers to allow us to place hippos in clockwise order. By cycling through this array, we choose
 // which sides the hippos are added to and in which proportion. We choose to add twice as many
 // hippos to the top and bottom of the screen as to the sides, which looks better on wide-screen
-// displays (which is moslty what we're supporting at this point).
+// displays (which is mostly what we're supporting at this point).
 const SIDES = [
     { array: app.topHippos, side: TOP_SIDE },
     { array: app.topHippos, side: TOP_SIDE },
@@ -103,9 +108,19 @@ socket.onmessage = (event) => {
         let to = { repeat: 1, yoyo: true, overwrite: 'none' };
         to[sideName] = '100px';
 
-        TweenMax.fromTo(element, .2, from, to);
+        TweenMax.fromTo(element, 0.2, from, to);
     } else if (payload['BeginNoseGoes']) {
         app.noseGoes.isActive = true;
+    } else if (payload['BonusWinner']) {
+        let event = payload['BonusWinner'];
+        let bonusWinner = app.hippoMap[event.id];
+        bonusWinner.wonBonus = true;
+
+        // Start the animation once the element has been added to the DOM.
+        Vue.nextTick(() => {
+            let element = document.getElementById('bonus-text');
+            TweenMax.to(element, 0.5, { scale: 1.2, repeat: -1, yoyo: true });
+        });
     } else if (payload['EndNoseGoes']) {
         app.noseGoes.isActive = false;
 
@@ -117,6 +132,7 @@ socket.onmessage = (event) => {
         if (info.bonus_winner != null) {
             let bonusWinner = app.hippoMap[info.bonus_winner[0]];
             bonusWinner.player.score = info.bonus_winner[1];
+            bonusWinner.wonBonus = false;
         }
     } else if (payload['UpdateWinner']) {
         for (let key in app.hippoMap) {
@@ -159,6 +175,7 @@ function addPlayer(player) {
         side: side,
         isDead: false,
         hasCrown: player.has_crown,
+        wonBonus: false,
     };
 
     // Add the hippo to the hippo map and its side of the screen.


### PR DESCRIPTION
I've updated the nose-goes feature to award bonus points to the first person (who's not already winning) to tap their screen. The bonus winner is awarded the points of each knocked out player, with a minimum of 100 points for each knocked out player. The host display shows a message saying "Speedy Bonus!" over the bonus winner while the nose-goes event is in progress. The message is a big ugly, but it's going to have to work since we don't have time to iterate on it much.