### PR TITLE
Reload host and client after disconnect

### DIFF
--- a/www/client.js
+++ b/www/client.js
@@ -124,9 +124,16 @@ socket.onerror = function(error) {
     console.error(error);
 };
 
-socket.onclose = function(event) {
-    // TODO: Re-open the connection, if possible.
-    console.error('Socket closed I guess: ', event);
+socket.onclose = (event) => {
+    function tryReconnect() {
+        get(
+            '/api/players',
+            () => { window.location.reload(true); },
+            () => { setTimeout(tryReconnect, 1000); },
+        );
+    }
+
+    tryReconnect();
 };
 
 function registerPlayer() {

--- a/www/host.js
+++ b/www/host.js
@@ -146,9 +146,19 @@ socket.onmessage = (event) => {
         console.error('Unrecognized host event:', payload);
     }
 };
+
 socket.onclose = (event) => {
-    console.error('Socket closed:', event);
+    function tryReconnect() {
+        get(
+            '/api/players',
+            () => { window.location.reload(true); },
+            () => { setTimeout(tryReconnect, 1000); },
+        );
+    }
+
+    tryReconnect();
 };
+
 
 // When we first boot up we need to get the current list of players.
 get('/api/players', response => {

--- a/www/request.js
+++ b/www/request.js
@@ -10,6 +10,8 @@ function get(endpoint, onResponse, onError) {
             onError(request.status);
         }
     });
+
+    request.addEventListener('error', onError);
     request.open('GET', endpoint);
     request.send();
 }


### PR DESCRIPTION
The host and client sites could already detect when they disconnected with the host. I've added functionality to allow them to detect when the server comes back on online and then refresh automatically. This should keep the host display from dying if the internet ever drops out or if updates get pushed live.